### PR TITLE
Fix CLI path resolution in app routes and allow sync init on empty remotes

### DIFF
--- a/app/app/api/restart/route.ts
+++ b/app/app/api/restart/route.ts
@@ -1,12 +1,14 @@
 export const dynamic = 'force-dynamic';
 import { NextResponse } from 'next/server';
 import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
 
 export async function POST() {
   try {
-    // process.cwd() is the Next.js app directory; cli.js is one level up at project root/bin/
-    const cliPath = resolve(process.cwd(), '../bin/cli.js');
+    const cliPath = process.env.MINDOS_CLI_PATH;
+    const nodeBin = process.env.MINDOS_NODE_BIN || process.execPath;
+    if (!cliPath) {
+      throw new Error('MindOS CLI path is unavailable. Restart MindOS from the `mindos` command.');
+    }
     // Use 'restart' (stop all → wait for ports free → start) instead of bare
     // 'start' which would fail assertPortFree because the current process and
     // its MCP child are still holding the ports.
@@ -28,7 +30,7 @@ export async function POST() {
     delete childEnv.WEB_PASSWORD;
     if (oldWebPort) childEnv.MINDOS_OLD_WEB_PORT = oldWebPort;
     if (oldMcpPort) childEnv.MINDOS_OLD_MCP_PORT = oldMcpPort;
-    const child = spawn(process.execPath, [cliPath, 'restart'], {
+    const child = spawn(nodeBin, [cliPath, 'restart'], {
       detached: true,
       stdio: 'ignore',
       env: childEnv,

--- a/app/app/api/sync/route.ts
+++ b/app/app/api/sync/route.ts
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { execSync, execFile } from 'child_process';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { homedir } from 'os';
 
 const MINDOS_DIR = join(homedir(), '.mindos');
@@ -35,6 +35,15 @@ function getUnpushedCount(cwd: string) {
 
 function isGitRepo(dir: string) {
   return existsSync(join(dir, '.git'));
+}
+
+function getCliInvocation() {
+  const cliPath = process.env.MINDOS_CLI_PATH;
+  const nodeBin = process.env.MINDOS_NODE_BIN || process.execPath;
+  if (!cliPath) {
+    throw new Error('MindOS CLI path is unavailable. Restart MindOS from the `mindos` command.');
+  }
+  return { cliPath, nodeBin };
 }
 
 export async function GET() {
@@ -99,12 +108,12 @@ export async function POST(req: NextRequest) {
 
         // Call CLI's sync init — pass clean remote + token separately (never embed token in URL)
         try {
-          const cliPath = resolve(process.cwd(), '..', 'bin', 'cli.js');
+          const { cliPath, nodeBin } = getCliInvocation();
           const args = ['sync', 'init', '--non-interactive', '--remote', remote, '--branch', branch];
           if (body.token) args.push('--token', body.token);
 
           await new Promise<void>((res, rej) => {
-            execFile('node', [cliPath, ...args], { timeout: 30000 }, (err, stdout, stderr) => {
+            execFile(nodeBin, [cliPath, ...args], { timeout: 30000 }, (err, stdout, stderr) => {
               if (err) rej(new Error(stderr?.trim() || err.message));
               else res();
             });
@@ -122,9 +131,9 @@ export async function POST(req: NextRequest) {
         }
         // Delegate to CLI for unified conflict handling
         try {
-          const cliPath = resolve(process.cwd(), '..', 'bin', 'cli.js');
+          const { cliPath, nodeBin } = getCliInvocation();
           await new Promise<void>((res, rej) => {
-            execFile('node', [cliPath, 'sync', 'now'], { timeout: 60000 }, (err, stdout, stderr) => {
+            execFile(nodeBin, [cliPath, 'sync', 'now'], { timeout: 60000 }, (err, stdout, stderr) => {
               if (err) rej(new Error(stderr?.trim() || err.message));
               else res();
             });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -197,6 +197,8 @@ const commands = {
   // ── dev ────────────────────────────────────────────────────────────────────
   dev: async () => {
     loadConfig();
+    process.env.MINDOS_CLI_PATH = resolve(ROOT, 'bin', 'cli.js');
+    process.env.MINDOS_NODE_BIN = process.execPath;
     const webPort = process.env.MINDOS_WEB_PORT || '3000';
     const mcpPort = process.env.MINDOS_MCP_PORT || '8787';
     await assertPortFree(Number(webPort), 'web');
@@ -283,6 +285,8 @@ const commands = {
       await assertPortFree(Number(webPort), 'web');
       await assertPortFree(Number(mcpPort), 'mcp');
     }
+    process.env.MINDOS_CLI_PATH = resolve(ROOT, 'bin', 'cli.js');
+    process.env.MINDOS_NODE_BIN = process.execPath;
     ensureAppDeps();
     if (needsBuild()) {
       console.log(yellow('Building MindOS (first run or new version detected)...\n'));

--- a/bin/lib/sync.js
+++ b/bin/lib/sync.js
@@ -249,7 +249,9 @@ export async function initSync(mindRoot, opts = {}) {
   // 5. Test connection
   if (!nonInteractive) console.log(dim('Testing connection...'));
   try {
-    execSync('git ls-remote --exit-code origin', { cwd: mindRoot, stdio: 'pipe', timeout: 15000 });
+    // `git ls-remote --exit-code origin` returns non-zero for an empty remote,
+    // which breaks first-time setup against a freshly created repository.
+    execSync('git ls-remote origin', { cwd: mindRoot, stdio: 'pipe', timeout: 15000 });
     if (!nonInteractive) console.log(green('✔ Connection successful'));
   } catch {
     const errMsg = 'Remote not reachable — check URL and credentials';


### PR DESCRIPTION
## Summary
- pass the resolved CLI path and node binary through env vars so app routes do not rely on dynamic filesystem resolution that Turbopack cannot bundle
- reuse that CLI invocation in the restart and sync API routes
- treat an empty remote repository as a valid sync target during `mindos sync init`

## Verification
- `node bin/cli.js build`
- verified local startup succeeds after the route fix
- verified sync init no longer rejects an empty remote repository during first-time setup