### PR TITLE
fix(app): merge abort signals in apiFetch

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -27,14 +27,30 @@ export async function apiFetch<T>(url: string, opts: ApiFetchOptions = {}): Prom
 
   let controller: AbortController | undefined;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let removeExternalAbortListener: (() => void) | undefined;
 
-  if (timeout > 0) {
+  if (timeout > 0 || externalSignal) {
     controller = new AbortController();
-    timeoutId = setTimeout(() => controller!.abort(), timeout);
   }
 
-  // Merge external signal if provided
-  const signal = externalSignal ?? controller?.signal;
+  if (timeout > 0 && controller) {
+    timeoutId = setTimeout(() => controller.abort(), timeout);
+  }
+
+  // Bridge caller-provided AbortSignal so both timeout and external cancel work.
+  if (externalSignal && controller) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      const onAbort = () => controller?.abort();
+      externalSignal.addEventListener('abort', onAbort, { once: true });
+      removeExternalAbortListener = () => {
+        externalSignal.removeEventListener('abort', onAbort);
+      };
+    }
+  }
+
+  const signal = controller?.signal ?? externalSignal;
 
   try {
     const res = await fetch(url, { ...fetchOpts, signal });
@@ -51,5 +67,6 @@ export async function apiFetch<T>(url: string, opts: ApiFetchOptions = {}): Prom
     return (await res.json()) as T;
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
+    if (removeExternalAbortListener) removeExternalAbortListener();
   }
 }


### PR DESCRIPTION
Ensure apiFetch honors both timeout cancellation and caller-provided AbortSignal.\n\nPreviously, providing an external signal could bypass the internal timeout signal.\nThis patch bridges the external signal into a shared AbortController so either source can abort the request.\n\nAlso cleans up the external abort event listener in finally to avoid leaks.