### PR TITLE
fix: respect explicit non-zh locale env vars in setup

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -186,16 +186,18 @@ function write(s) { process.stdout.write(s); }
 // ── State ─────────────────────────────────────────────────────────────────────
 
 function detectSystemLang() {
-  // Check env vars first (Linux / macOS / WSL)
-  const vars = [
-    process.env.LANG,
+  // Check env vars by precedence (LC_ALL > LC_MESSAGES > LANG > LANGUAGE)
+  // For LANGUAGE, only use the first entry before ':' (it's a priority list)
+  const candidates = [
     process.env.LC_ALL,
     process.env.LC_MESSAGES,
-    process.env.LANGUAGE,
-  ].filter(Boolean).join(' ').toLowerCase();
-  if (vars.includes('zh')) return 'zh';
-  // If any env var is set, trust it — don't fall through to Intl
-  if (vars.length > 0) return 'en';
+    process.env.LANG,
+    ...(process.env.LANGUAGE ? [process.env.LANGUAGE.split(':')[0]] : []),
+  ];
+  const first = candidates.find(Boolean);
+  if (first) {
+    return first.toLowerCase().startsWith('zh') ? 'zh' : 'en';
+  }
 
   // Fallback: Intl API (works on Windows where LANG is often unset)
   try {

--- a/tests/unit/detect-system-lang.test.ts
+++ b/tests/unit/detect-system-lang.test.ts
@@ -4,34 +4,23 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 // 与源码保持结构一致，方便比对。
 
 function detectSystemLang(env: Record<string, string | undefined> = process.env as Record<string, string | undefined>): string {
-  const vars = [env.LANG, env.LC_ALL, env.LC_MESSAGES, env.LANGUAGE]
-    .filter(Boolean).join(' ').toLowerCase();
-  if (vars.includes('zh')) return 'zh';
-  // If any env var is set, trust it — don't fall through to Intl
-  if (vars.length > 0) return 'en';
+  // Check env vars by precedence (LC_ALL > LC_MESSAGES > LANG > LANGUAGE)
+  // For LANGUAGE, only use the first entry before ':' (it's a priority list)
+  const candidates = [
+    env.LC_ALL,
+    env.LC_MESSAGES,
+    env.LANG,
+    ...(env.LANGUAGE ? [env.LANGUAGE.split(':')[0]] : []),
+  ];
+  const first = candidates.find(Boolean);
+  if (first) {
+    return first.toLowerCase().startsWith('zh') ? 'zh' : 'en';
+  }
   try {
     const locale = Intl.DateTimeFormat().resolvedOptions().locale;
     if (locale.toLowerCase().startsWith('zh')) return 'zh';
   } catch {}
   return 'en';
-}
-
-// ── 保存/还原 env 的辅助 ───────────────────────────────────────────────────
-const ENV_KEYS = ['LANG', 'LC_ALL', 'LC_MESSAGES', 'LANGUAGE'] as const;
-
-function withEnv(overrides: Partial<Record<typeof ENV_KEYS[number], string | undefined>>, fn: () => void) {
-  const saved: Record<string, string | undefined> = {};
-  for (const k of ENV_KEYS) {
-    saved[k] = process.env[k];
-    if (overrides[k] === undefined) delete process.env[k];
-    else process.env[k] = overrides[k];
-  }
-  try { fn(); } finally {
-    for (const k of ENV_KEYS) {
-      if (saved[k] === undefined) delete process.env[k];
-      else process.env[k] = saved[k];
-    }
-  }
 }
 
 // ── 通过参数注入 env 的测试（不污染 process.env）─────────────────────────────
@@ -53,7 +42,7 @@ describe('detectSystemLang — 中文环境检测', () => {
     expect(detectSystemLang({ LANG: undefined, LC_ALL: undefined, LC_MESSAGES: 'zh_CN.UTF-8' })).toBe('zh');
   });
 
-  it('LANGUAGE=zh_CN:en_US → zh', () => {
+  it('LANGUAGE=zh_CN:en_US → zh（首选项是 zh）', () => {
     expect(detectSystemLang({ LANG: undefined, LC_ALL: undefined, LC_MESSAGES: undefined, LANGUAGE: 'zh_CN:en_US' })).toBe('zh');
   });
 });
@@ -75,14 +64,37 @@ describe('detectSystemLang — 英文环境检测', () => {
 });
 
 describe('detectSystemLang — 优先级：env 变量优先于 Intl', () => {
-  it('LANG 包含 zh 即返回 zh，不走 Intl', () => {
-    // 即使 Intl 返回 en，LANG=zh_CN 也应返回 zh
-    expect(detectSystemLang({ LANG: 'zh_CN.UTF-8', LC_ALL: 'en_US.UTF-8' })).toBe('zh');
+  it('LC_ALL=zh 优先于 LANG=en → zh', () => {
+    expect(detectSystemLang({ LANG: 'en_US.UTF-8', LC_ALL: 'zh_CN.UTF-8' })).toBe('zh');
   });
 
   it('LANG=en、其他 env 无 zh → en（不论 Intl 结果）', () => {
     const result = detectSystemLang({ LANG: 'en_US.UTF-8', LC_ALL: undefined, LC_MESSAGES: undefined, LANGUAGE: undefined });
     expect(result).toBe('en');
+  });
+});
+
+describe('detectSystemLang — LANGUAGE 优先级列表', () => {
+  it('LANGUAGE=en_US:zh_CN → en（首选项是 en，zh 只是 fallback）', () => {
+    expect(detectSystemLang({ LANG: undefined, LC_ALL: undefined, LC_MESSAGES: undefined, LANGUAGE: 'en_US:zh_CN' })).toBe('en');
+  });
+
+  it('LANGUAGE=zh_CN:en_US → zh（首选项是 zh）', () => {
+    expect(detectSystemLang({ LANG: undefined, LC_ALL: undefined, LC_MESSAGES: undefined, LANGUAGE: 'zh_CN:en_US' })).toBe('zh');
+  });
+
+  it('LANG=en + LANGUAGE=zh_CN:en → en（LANG 优先于 LANGUAGE）', () => {
+    expect(detectSystemLang({ LANG: 'en_US.UTF-8', LC_ALL: undefined, LC_MESSAGES: undefined, LANGUAGE: 'zh_CN:en_US' })).toBe('en');
+  });
+});
+
+describe('detectSystemLang — 高优先级英文 + 低优先级中文', () => {
+  it('LC_ALL=en + LANG=zh → en（LC_ALL 优先级最高）', () => {
+    expect(detectSystemLang({ LANG: 'zh_CN.UTF-8', LC_ALL: 'en_US.UTF-8' })).toBe('en');
+  });
+
+  it('LC_MESSAGES=en + LANG=zh → en（LC_MESSAGES 优先于 LANG）', () => {
+    expect(detectSystemLang({ LANG: 'zh_CN.UTF-8', LC_ALL: undefined, LC_MESSAGES: 'en_US.UTF-8' })).toBe('en');
   });
 });
 
@@ -98,5 +110,13 @@ describe('detectSystemLang — 边界条件', () => {
   it('env 中含 "ZH"（大写）也能识别', () => {
     // 实现 .toLowerCase() 后比较，所以大写也能匹配
     expect(detectSystemLang({ LANG: 'ZH_CN.UTF-8' })).toBe('zh');
+  });
+
+  it('LANG=fr_FR.UTF-8 → en（非中文非英文仍返回 en）', () => {
+    expect(detectSystemLang({ LANG: 'fr_FR.UTF-8' })).toBe('en');
+  });
+
+  it('LANG=ja_JP.UTF-8 → en（日文环境返回 en）', () => {
+    expect(detectSystemLang({ LANG: 'ja_JP.UTF-8' })).toBe('en');
   });
 });


### PR DESCRIPTION
## Summary
- fix `detectSystemLang()` so explicit env locale settings override the `Intl` fallback
- prevent zh-locale systems from forcing Chinese UI when `LANG=en_US.UTF-8` or similar is set
- keep `Intl` as fallback only when locale env vars are unset, and cover the behavior with regression tests

## Test plan
- [x] Run `npm test`
- [x] Verify all `detect-system-lang` regression cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)