### PR TITLE
fix: ensure the MCP bundle is built for source installations

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -57,6 +57,7 @@ import { stopMindos } from './lib/stop.js';
 import { getPlatform, ensureMindosDir, waitForHttp, waitForPortFree, runGatewayCommand } from './lib/gateway.js';
 import { printStartupInfo, getLocalIP } from './lib/startup.js';
 import { spawnMcp } from './lib/mcp-spawn.js';
+import { ensureMcpBundle } from './lib/mcp-build.js';
 import { mcpInstall } from './lib/mcp-install.js';
 import { initSync, startSyncDaemon, stopSyncDaemon, getSyncStatus, manualSync, listConflicts, setSyncEnabled } from './lib/sync.js';
 
@@ -422,11 +423,7 @@ const commands = {
     const hasInstallFlags = restArgs.some(a => ['-g', '--global', '-y', '--yes'].includes(a));
     if (sub === 'install' || hasInstallFlags) { await mcpInstall(); return; }
     loadConfig();
-    const mcpSdk = resolve(ROOT, 'mcp', 'node_modules', '@modelcontextprotocol', 'sdk', 'package.json');
-    if (!existsSync(mcpSdk)) {
-      console.log(yellow('Installing MCP dependencies (first run)...\n'));
-      npmInstall(resolve(ROOT, 'mcp'), '--no-workspaces');
-    }
+    ensureMcpBundle();
     // `mindos mcp` is the entry point for MCP clients (Claude Code, Cursor, etc.)
     // which communicate over stdin/stdout. Default to stdio; HTTP is handled by
     // `mindos start` via spawnMcp(). Callers can still override via env.

--- a/bin/lib/mcp-build.js
+++ b/bin/lib/mcp-build.js
@@ -1,0 +1,74 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ROOT } from './constants.js';
+import { yellow } from './colors.js';
+import { run, npmInstall } from './utils.js';
+
+export const MCP_DIR = resolve(ROOT, 'mcp');
+export const MCP_SRC_DIR = resolve(MCP_DIR, 'src');
+export const MCP_BUNDLE = resolve(MCP_DIR, 'dist', 'index.cjs');
+
+const MCP_PACKAGE_JSON = resolve(MCP_DIR, 'package.json');
+const MCP_PACKAGE_LOCK = resolve(MCP_DIR, 'package-lock.json');
+const MCP_SDK = resolve(MCP_DIR, 'node_modules', '@modelcontextprotocol', 'sdk', 'package.json');
+const MCP_ESBUILD = resolve(MCP_DIR, 'node_modules', 'esbuild', 'package.json');
+
+function safeMtime(filePath) {
+  try {
+    return statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function latestTreeMtime(dirPath) {
+  if (!existsSync(dirPath)) return 0;
+
+  let latest = safeMtime(dirPath);
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    const fullPath = resolve(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      latest = Math.max(latest, latestTreeMtime(fullPath));
+    } else {
+      latest = Math.max(latest, safeMtime(fullPath));
+    }
+  }
+  return latest;
+}
+
+function hasBuildDeps() {
+  return existsSync(MCP_SDK) && existsSync(MCP_ESBUILD);
+}
+
+export function needsMcpBuild() {
+  if (!existsSync(MCP_BUNDLE)) return true;
+
+  const bundleMtime = safeMtime(MCP_BUNDLE);
+  const sourceMtime = Math.max(
+    latestTreeMtime(MCP_SRC_DIR),
+    safeMtime(MCP_PACKAGE_JSON),
+    safeMtime(MCP_PACKAGE_LOCK),
+  );
+
+  return sourceMtime > bundleMtime;
+}
+
+export function ensureMcpBundle() {
+  if (!needsMcpBuild()) return;
+
+  const hadBundle = existsSync(MCP_BUNDLE);
+
+  if (!hasBuildDeps()) {
+    console.log(yellow('Installing MCP build dependencies...\n'));
+    npmInstall(MCP_DIR, '--no-workspaces');
+  }
+
+  console.log(yellow(hadBundle
+    ? 'Rebuilding MCP bundle (source changed)...\n'
+    : 'Building MCP bundle (first run)...\n'));
+  run('npm run build', MCP_DIR);
+
+  if (!existsSync(MCP_BUNDLE)) {
+    throw new Error(`MCP bundle build did not produce ${MCP_BUNDLE}`);
+  }
+}

--- a/bin/lib/mcp-spawn.js
+++ b/bin/lib/mcp-spawn.js
@@ -1,17 +1,20 @@
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ROOT, CONFIG_PATH } from './constants.js';
 import { bold, red } from './colors.js';
+import { ensureMcpBundle, MCP_BUNDLE } from './mcp-build.js';
 
 export function spawnMcp(verbose = false) {
   const mcpPort = process.env.MINDOS_MCP_PORT || '8781';
   const webPort = process.env.MINDOS_WEB_PORT || '3456';
 
-  const mcpBundle = resolve(ROOT, 'mcp', 'dist', 'index.cjs');
-  if (!existsSync(mcpBundle)) {
+  try {
+    ensureMcpBundle();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `MCP bundle not found: ${mcpBundle}\n` +
+      `${message}\n` +
       `This MindOS installation may be corrupted. Try: npm install -g @geminilight/mindos@latest`,
     );
   }
@@ -31,7 +34,7 @@ export function spawnMcp(verbose = false) {
     ...(configAuthToken ? { AUTH_TOKEN: configAuthToken } : {}),
     ...(verbose ? { MCP_VERBOSE: '1' } : {}),
   };
-  const child = spawn(process.execPath, [mcpBundle], {
+  const child = spawn(process.execPath, [MCP_BUNDLE], {
     cwd: resolve(ROOT, 'mcp'),
     stdio: 'inherit',
     env,

--- a/tests/unit/cli-mcp-stdio-default.test.ts
+++ b/tests/unit/cli-mcp-stdio-default.test.ts
@@ -14,7 +14,7 @@ import { join } from 'path';
  * mcp/src/index.ts fell through to the default "http" transport.
  */
 
-const MCP_BUNDLE = join(__dirname, '../../mcp/dist/index.cjs');
+const CLI = join(__dirname, '../../bin/cli.js');
 
 const children: ChildProcess[] = [];
 
@@ -61,7 +61,7 @@ describe('mindos mcp stdio transport (regression)', () => {
       blocker!.on('error', reject);
     });
 
-    const proc = spawn(process.execPath, [MCP_BUNDLE], {
+    const proc = spawn(process.execPath, [CLI, 'mcp'], {
       env: {
         ...process.env,
         MCP_TRANSPORT: 'stdio',

--- a/tests/unit/mcp-build.test.ts
+++ b/tests/unit/mcp-build.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+let tempDir: string;
+let mcpDir: string;
+let srcDir: string;
+let distDir: string;
+let bundlePath: string;
+let sdkPkgPath: string;
+let esbuildPkgPath: string;
+let mockRun: ReturnType<typeof vi.fn>;
+let mockInstall: ReturnType<typeof vi.fn>;
+
+function setMtime(targetPath: string, timeMs: number) {
+  const time = new Date(timeMs);
+  fs.utimesSync(targetPath, time, time);
+}
+
+function writeBundle(content = '// bundle') {
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(bundlePath, content);
+}
+
+function writeBuildDeps() {
+  fs.mkdirSync(path.dirname(sdkPkgPath), { recursive: true });
+  fs.writeFileSync(sdkPkgPath, '{}');
+  fs.mkdirSync(path.dirname(esbuildPkgPath), { recursive: true });
+  fs.writeFileSync(esbuildPkgPath, '{}');
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mindos-mcp-build-test-'));
+  mcpDir = path.join(tempDir, 'mcp');
+  srcDir = path.join(mcpDir, 'src');
+  distDir = path.join(mcpDir, 'dist');
+  bundlePath = path.join(distDir, 'index.cjs');
+  sdkPkgPath = path.join(mcpDir, 'node_modules', '@modelcontextprotocol', 'sdk', 'package.json');
+  esbuildPkgPath = path.join(mcpDir, 'node_modules', 'esbuild', 'package.json');
+
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.writeFileSync(path.join(srcDir, 'index.ts'), 'export const ok = true;');
+  fs.writeFileSync(path.join(mcpDir, 'package.json'), JSON.stringify({ name: 'mindos-mcp', version: '1.0.0' }));
+  fs.writeFileSync(path.join(mcpDir, 'package-lock.json'), JSON.stringify({ lockfileVersion: 3 }));
+
+  mockInstall = vi.fn(() => {
+    writeBuildDeps();
+  });
+  mockRun = vi.fn((command: string) => {
+    if (command === 'npm run build') {
+      writeBundle();
+    }
+  });
+
+  vi.resetModules();
+  vi.doMock('../../bin/lib/constants.js', () => ({
+    ROOT: tempDir,
+    BUILD_STAMP: path.join(tempDir, 'app', '.next', '.mindos-build-version'),
+    DEPS_STAMP: path.join(tempDir, 'deps-hash'),
+    CONFIG_PATH: path.join(tempDir, 'config.json'),
+    MINDOS_DIR: tempDir,
+    PID_PATH: path.join(tempDir, 'mindos.pid'),
+    LOG_PATH: path.join(tempDir, 'mindos.log'),
+    CLI_PATH: path.join(tempDir, 'bin', 'cli.js'),
+    NODE_BIN: process.execPath,
+    UPDATE_CHECK_PATH: path.join(tempDir, 'update-check.json'),
+  }));
+  vi.doMock('../../bin/lib/utils.js', () => ({
+    run: mockRun,
+    npmInstall: mockInstall,
+  }));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function importMcpBuild() {
+  return await import('../../bin/lib/mcp-build.js') as {
+    needsMcpBuild: () => boolean;
+    ensureMcpBundle: () => void;
+  };
+}
+
+describe('needsMcpBuild', () => {
+  it('returns true when the MCP bundle is missing', async () => {
+    const { needsMcpBuild } = await importMcpBuild();
+    expect(needsMcpBuild()).toBe(true);
+  });
+
+  it('returns false when the bundle is newer than source inputs', async () => {
+    writeBundle();
+    const now = Date.now();
+    setMtime(srcDir, now - 10_000);
+    setMtime(path.join(srcDir, 'index.ts'), now - 10_000);
+    setMtime(path.join(mcpDir, 'package.json'), now - 10_000);
+    setMtime(path.join(mcpDir, 'package-lock.json'), now - 10_000);
+    setMtime(bundlePath, now);
+
+    const { needsMcpBuild } = await importMcpBuild();
+    expect(needsMcpBuild()).toBe(false);
+  });
+
+  it('returns true when source changes after the bundle was built', async () => {
+    writeBundle();
+    const now = Date.now();
+    setMtime(bundlePath, now - 20_000);
+    setMtime(path.join(srcDir, 'index.ts'), now);
+
+    const { needsMcpBuild } = await importMcpBuild();
+    expect(needsMcpBuild()).toBe(true);
+  });
+});
+
+describe('ensureMcpBundle', () => {
+  it('installs build deps and builds when the bundle is missing', async () => {
+    const { ensureMcpBundle } = await importMcpBuild();
+
+    ensureMcpBundle();
+
+    expect(mockInstall).toHaveBeenCalledWith(mcpDir, '--no-workspaces');
+    expect(mockRun).toHaveBeenCalledWith('npm run build', mcpDir);
+    expect(fs.existsSync(bundlePath)).toBe(true);
+  });
+
+  it('rebuilds stale bundles without reinstalling build deps', async () => {
+    writeBuildDeps();
+    writeBundle();
+    const now = Date.now();
+    setMtime(bundlePath, now - 20_000);
+    setMtime(path.join(srcDir, 'index.ts'), now);
+
+    const { ensureMcpBundle } = await importMcpBuild();
+
+    ensureMcpBundle();
+
+    expect(mockInstall).not.toHaveBeenCalled();
+    expect(mockRun).toHaveBeenCalledWith('npm run build', mcpDir);
+  });
+
+  it('does nothing when the bundle is already current', async () => {
+    writeBuildDeps();
+    writeBundle();
+    const now = Date.now();
+    setMtime(srcDir, now - 10_000);
+    setMtime(path.join(srcDir, 'index.ts'), now - 10_000);
+    setMtime(path.join(mcpDir, 'package.json'), now - 10_000);
+    setMtime(path.join(mcpDir, 'package-lock.json'), now - 10_000);
+    setMtime(bundlePath, now);
+
+    const { ensureMcpBundle } = await importMcpBuild();
+
+    ensureMcpBundle();
+
+    expect(mockInstall).not.toHaveBeenCalled();
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #4.

### Summary

This change fixes a source-installation failure in the MCP startup path.

With the current flow:

```bash
git clone
npm install
npm link
mindos mcp
```

the CLI installs MCP dependencies, but still assumes that `mcp/dist/index.cjs` already exists. On a fresh source checkout, that assumption is false, and `mindos mcp` fails with `MODULE_NOT_FOUND`.

### Changes

- add a small MCP build bootstrap helper
- build `mcp/dist/index.cjs` automatically when it is missing
- rebuild it when the MCP source tree is newer than the bundle
- wire this logic into both the standalone CLI MCP path and the shared MCP spawn path
- add focused regression coverage for missing and stale MCP bundle cases
- update the stdio regression test to exercise the real CLI entrypoint rather than assuming a prebuilt bundle

### Rationale

Packaged releases can reasonably assume that the MCP bundle already exists. A source checkout cannot.

This change makes the documented source installation flow self-sufficient without changing the packaged runtime model.

### Verification

Before this change, a clean source installation reproducibly failed because `mcp/dist/index.cjs` was absent at runtime.

After this change, the same flow builds the MCP bundle on demand and allows `mindos mcp` to complete MCP initialization successfully.

### Tests

```bash
node tests/integration/node_modules/vitest/vitest.mjs run \
  tests/unit/mcp-build.test.ts \
  tests/unit/cli-build.test.ts \
  tests/unit/cli-mcp-stdio-default.test.ts \
  --config tests/unit/vitest.config.ts
```
