### PR TITLE
fix: normalize bare tilde in setup paths

### DIFF
--- a/app/__tests__/api/setup-paths.test.ts
+++ b/app/__tests__/api/setup-paths.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+let fakeHome: string;
+
+beforeEach(() => {
+  fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mindos-setup-home-'));
+  fs.mkdirSync(path.join(fakeHome, 'Documents'), { recursive: true });
+  fs.mkdirSync(path.join(fakeHome, 'Projects'), { recursive: true });
+  fs.writeFileSync(path.join(fakeHome, '.hidden'), 'secret', 'utf-8');
+
+  vi.resetModules();
+  vi.doMock('node:os', async () => {
+    const actual = await vi.importActual<typeof import('node:os')>('node:os');
+    return {
+      ...actual,
+      homedir: () => fakeHome,
+    };
+  });
+});
+
+afterEach(() => {
+  vi.doUnmock('node:os');
+  vi.restoreAllMocks();
+  fs.rmSync(fakeHome, { recursive: true, force: true });
+});
+
+async function importCheckPathRoute() {
+  return await import('../../app/api/setup/check-path/route');
+}
+
+async function importLsRoute() {
+  return await import('../../app/api/setup/ls/route');
+}
+
+describe('setup path normalization', () => {
+  it('treats bare tilde as the home directory in check-path', async () => {
+    const { POST } = await importCheckPathRoute();
+    const req = new NextRequest('http://localhost/api/setup/check-path', {
+      method: 'POST',
+      body: JSON.stringify({ path: '~' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.exists).toBe(true);
+    expect(body.empty).toBe(false);
+    expect(body.count).toBe(2);
+  });
+
+  it('keeps ls and check-path consistent for bare tilde', async () => {
+    const { POST: listDirs } = await importLsRoute();
+    const { POST: checkPath } = await importCheckPathRoute();
+
+    const lsReq = new NextRequest('http://localhost/api/setup/ls', {
+      method: 'POST',
+      body: JSON.stringify({ path: '~' }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const checkReq = new NextRequest('http://localhost/api/setup/check-path', {
+      method: 'POST',
+      body: JSON.stringify({ path: '~' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const lsRes = await listDirs(lsReq);
+    const checkRes = await checkPath(checkReq);
+    const lsBody = await lsRes.json();
+    const checkBody = await checkRes.json();
+
+    expect(lsBody.dirs).toEqual(['Documents', 'Projects']);
+    expect(checkBody.exists).toBe(true);
+    expect(checkBody.count).toBe(lsBody.dirs.length);
+  });
+});

--- a/app/__tests__/api/setup.test.ts
+++ b/app/__tests__/api/setup.test.ts
@@ -166,6 +166,20 @@ describe('POST /api/setup — config writing', () => {
     expect((writtenConfig as Record<string, unknown>).setupPending).toBe(false);
   });
 
+  it('expands bare tilde to the real home directory before writing config', async () => {
+    const { POST } = await importSetupRoute();
+    const req = new NextRequest('http://localhost/api/setup', {
+      method: 'POST',
+      body: JSON.stringify({ mindRoot: '~', template: 'empty' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(writtenConfig).not.toBeNull();
+    expect((writtenConfig as Record<string, unknown>).mindRoot).toBe(os.homedir());
+  });
+
   it('sets disabledSkills=["mindos-zh"] for en template', async () => {
     const { POST } = await importSetupRoute();
     const req = new NextRequest('http://localhost/api/setup', {

--- a/app/app/api/setup/check-path/route.ts
+++ b/app/app/api/setup/check-path/route.ts
@@ -1,12 +1,7 @@
 export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { existsSync, readdirSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { resolve } from 'node:path';
-
-function expandHome(p: string): string {
-  return p.startsWith('~/') ? resolve(homedir(), p.slice(2)) : p;
-}
+import { expandSetupPathHome } from '../path-utils';
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,7 +9,7 @@ export async function POST(req: NextRequest) {
     if (!path || typeof path !== 'string') {
       return NextResponse.json({ error: 'Invalid path' }, { status: 400 });
     }
-    const abs = expandHome(path.trim());
+    const abs = expandSetupPathHome(path.trim());
     const exists = existsSync(abs);
     let empty = true;
     let count = 0;

--- a/app/app/api/setup/ls/route.ts
+++ b/app/app/api/setup/ls/route.ts
@@ -1,14 +1,8 @@
 export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { existsSync, readdirSync, statSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { resolve, join } from 'node:path';
-
-function expandHome(p: string): string {
-  if (p === '~') return homedir();
-  if (p.startsWith('~/') || p.startsWith('~\\')) return resolve(homedir(), p.slice(2));
-  return p;
-}
+import { join } from 'node:path';
+import { expandSetupPathHome } from '../path-utils';
 
 export async function POST(req: NextRequest) {
   try {
@@ -16,7 +10,7 @@ export async function POST(req: NextRequest) {
     if (!path || typeof path !== 'string') {
       return NextResponse.json({ dirs: [] });
     }
-    const abs = expandHome(path.trim());
+    const abs = expandSetupPathHome(path.trim());
     if (!existsSync(abs)) {
       return NextResponse.json({ dirs: [] });
     }

--- a/app/app/api/setup/path-utils.ts
+++ b/app/app/api/setup/path-utils.ts
@@ -1,0 +1,8 @@
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+export function expandSetupPathHome(p: string): string {
+  if (p === '~') return homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) return resolve(homedir(), p.slice(2));
+  return p;
+}

--- a/app/app/api/setup/route.ts
+++ b/app/app/api/setup/route.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import os from 'os';
 import { readSettings, writeSettings, ServerSettings } from '@/lib/settings';
 import { applyTemplate } from '@/lib/template';
+import { expandSetupPathHome } from './path-utils';
 
 function maskApiKey(key: string): string {
   if (!key || key.length < 6) return key ? '***' : '';
@@ -40,12 +41,6 @@ export async function GET() {
   }
 }
 
-function expandHome(p: string): string {
-  if (p.startsWith('~/')) return p.replace('~', os.homedir());
-  if (p === '~') return os.homedir();
-  return p;
-}
-
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
@@ -56,7 +51,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'mindRoot is required' }, { status: 400 });
     }
 
-    const resolvedRoot = expandHome(mindRoot.trim());
+    const resolvedRoot = expandSetupPathHome(mindRoot.trim());
 
     // Validate ports
     const webPort = typeof port === 'number' ? port : 3456;


### PR DESCRIPTION
Closes #6.

### Summary

This change normalizes bare `~` consistently across the setup flow.

Before this patch, onboarding handled `~` inconsistently:

- `POST /api/setup/ls` treated `~` as the user's home directory
- `POST /api/setup` expanded `~` before persisting config
- `POST /api/setup/check-path` did not expand bare `~`

As a result, the setup UI could suggest directories from the home directory while simultaneously reporting the same input as missing or empty.

### Changes

- add a shared setup path normalization helper
- use the helper in setup path validation
- use the helper in setup directory listing / autocomplete
- use the helper in final setup persistence
- add focused regression coverage for bare `~` handling

### Rationale

The onboarding flow should treat the same filesystem input consistently at every step.

This patch keeps the scope narrow and only changes setup path normalization, while aligning validation, autocomplete, and persistence behavior.

### Verification

Bug validation:

1. Focused route-level regression coverage reproduced the inconsistency before the fix.
2. Static UI/dataflow inspection showed that `StepKB` relies on both `/api/setup/ls` and `/api/setup/check-path`, so their disagreement was user-visible in onboarding.

Fix validation:

1. Focused setup API tests now pass.
2. The full app test suite passes after the change.

### Tests

```bash
npx vitest run /Users/urara/Code/MindOS/app/__tests__/api/setup-paths.test.ts /Users/urara/Code/MindOS/app/__tests__/api/setup.test.ts --config vitest.config.ts
npx vitest run
```
