### PR TITLE
fix: resolve updated install root during CLI updates

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -40,7 +40,7 @@
 
 import { execSync, spawn as nodeSpawn } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, rmSync, cpSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 
 import { ROOT, CONFIG_PATH, BUILD_STAMP, LOG_PATH, MINDOS_DIR } from './lib/constants.js';

--- a/tests/unit/cli-update-root.test.ts
+++ b/tests/unit/cli-update-root.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const CLI = path.join(ROOT, 'bin', 'cli.js');
+
+let tempDir: string;
+let fakeBinDir: string;
+let fakeInstallRoot: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mindos-update-root-'));
+  fakeBinDir = path.join(tempDir, 'fake-bin');
+  fakeInstallRoot = path.join(tempDir, 'new-root');
+
+  fs.mkdirSync(fakeBinDir, { recursive: true });
+  fs.mkdirSync(path.join(fakeInstallRoot, 'bin'), { recursive: true });
+  fs.mkdirSync(path.join(fakeInstallRoot, 'app', '.next'), { recursive: true });
+
+  fs.writeFileSync(path.join(fakeBinDir, 'npm'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(fakeInstallRoot, 'bin', 'cli.js'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  fs.symlinkSync(path.join(fakeInstallRoot, 'bin', 'cli.js'), path.join(fakeBinDir, 'mindos'));
+  fs.writeFileSync(
+    path.join(fakeInstallRoot, 'package.json'),
+    JSON.stringify({ name: '@geminilight/mindos', version: '9.9.9' }),
+  );
+  fs.writeFileSync(
+    path.join(fakeInstallRoot, 'app', '.next', '.mindos-build-version'),
+    '9.9.9',
+  );
+  fs.writeFileSync(
+    path.join(fakeInstallRoot, 'app', 'package.json'),
+    JSON.stringify({ name: 'wiki-app', version: '0.1.0' }),
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('mindos update root resolution', () => {
+  it('uses the resolved installed CLI path instead of falling back to the current repo root', () => {
+    const stdout = execFileSync(process.execPath, [CLI, 'update'], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH}`,
+      },
+      timeout: 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    expect(stdout).toContain('Updated: 0.6.8 → 9.9.9');
+    expect(stdout).not.toContain('Already on the latest version');
+  });
+});


### PR DESCRIPTION
Closes #8.

### Summary

This change fixes the installation-root resolution used by `mindos update`.

Before this patch, the update flow could silently fall back to the current repository root instead of the newly installed CLI location. In affected layouts, that caused update version checks to read from the wrong installation directory and incorrectly report that the current version was already up to date.

### Changes

- fix `getUpdatedRoot()` so it resolves the installed CLI root correctly
- add focused regression coverage for the update root resolution path

### Rationale

The update command should evaluate the version and build state of the newly installed MindOS location, not the stale root from the currently running process.

This patch keeps the fix narrow and only changes the root resolution path used during CLI updates.

### Verification

Bug validation:

1. Command-level reproduction on `origin/main` with a fake PATH-installed `mindos` at a different root showed `mindos update` incorrectly printing `Already on the latest version (0.6.8)`.
2. Direct helper-level evaluation on `origin/main` showed `getUpdatedRoot()` returning the old `ROOT` even when `which mindos` resolved to a different installed path.

Fix validation:

1. Focused CLI regression tests pass.
2. The same command-level reproduction now reports the correct version transition (`0.6.8 → 9.9.9`).

### Tests

```bash
node tests/integration/node_modules/vitest/vitest.mjs run \
  tests/unit/cli-update-root.test.ts \
  tests/unit/cli-smoke.test.ts \
  --config tests/unit/vitest.config.ts
```
