### PR TITLE
fix: surface immediate browser update failures

### DIFF
--- a/app/__tests__/settings/update-tab-browser.test.tsx
+++ b/app/__tests__/settings/update-tab-browser.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const mockApiFetch = vi.fn();
+
+class MockApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+vi.mock('@/lib/api', () => ({
+  apiFetch: mockApiFetch,
+  ApiError: MockApiError,
+}));
+
+vi.mock('@/lib/LocaleContext', () => ({
+  useLocale: () => ({
+    locale: 'en' as const,
+    t: {
+      settings: {
+        update: {
+          checking: 'Checking for updates...',
+          error: 'Failed to check for updates.',
+          upToDate: "You're up to date",
+          available: (current: string, latest: string) => `Update available: v${current} → v${latest}`,
+          timeout: 'Update may still be in progress.',
+          timeoutHint: 'The server may need more time to rebuild. Try refreshing.',
+          refreshButton: 'Refresh Page',
+          retryButton: 'Retry Update',
+          releaseNotes: 'View release notes',
+          hint: 'Updates are installed via npm. Equivalent to running',
+          inTerminal: 'in your terminal.',
+          checkButton: 'Check for Updates',
+          updateButton: (latest: string) => `Update to v${latest}`,
+          serverRestarting: 'Server is restarting, please wait...',
+          updatingHint: 'This may take 1–3 minutes. Do not close this page.',
+          updated: 'Updated successfully! Reloading...',
+        },
+      },
+    },
+  }),
+}));
+
+describe('Browser UpdateTab immediate failure handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  it('surfaces an immediate /api/update failure as an error instead of staying in updating state', async () => {
+    const { UpdateTab } = await import('@/components/settings/UpdateTab');
+
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url === '/api/update-check') {
+        return Promise.resolve({
+          current: '1.0.0',
+          latest: '2.0.0',
+          hasUpdate: true,
+        });
+      }
+      if (url === '/api/update') {
+        return Promise.reject(new MockApiError('spawn failed', 500));
+      }
+      if (url === '/api/update-status') {
+        return Promise.resolve({
+          stage: 'idle',
+          stages: [],
+          error: null,
+          version: null,
+          startedAt: null,
+        });
+      }
+      throw new Error(`Unexpected apiFetch call: ${url}`);
+    });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(<UpdateTab />);
+    });
+
+    const updateButton = Array.from(host.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Update to v2.0.0'),
+    ) as HTMLButtonElement | undefined;
+    expect(updateButton).toBeTruthy();
+
+    await act(async () => {
+      updateButton?.click();
+      await Promise.resolve();
+    });
+
+    expect(host.textContent).toContain('Retry Update');
+    expect(host.textContent).not.toContain('This may take 1–3 minutes. Do not close this page.');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('clears persisted update-in-progress state when /api/update fails immediately', async () => {
+    const { UpdateTab } = await import('@/components/settings/UpdateTab');
+
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url === '/api/update-check') {
+        return Promise.resolve({
+          current: '1.0.0',
+          latest: '2.0.0',
+          hasUpdate: true,
+        });
+      }
+      if (url === '/api/update') {
+        return Promise.reject(new MockApiError('spawn failed', 500));
+      }
+      if (url === '/api/update-status') {
+        return Promise.resolve({
+          stage: 'idle',
+          stages: [],
+          error: null,
+          version: null,
+          startedAt: null,
+        });
+      }
+      throw new Error(`Unexpected apiFetch call: ${url}`);
+    });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(<UpdateTab />);
+    });
+
+    const updateButton = Array.from(host.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Update to v2.0.0'),
+    ) as HTMLButtonElement | undefined;
+    expect(updateButton).toBeTruthy();
+
+    await act(async () => {
+      updateButton?.click();
+      await Promise.resolve();
+    });
+
+    expect(localStorage.getItem('mindos_update_in_progress')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/app/components/settings/UpdateTab.tsx
+++ b/app/components/settings/UpdateTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Download, RefreshCw, CheckCircle2, AlertCircle, Loader2, ExternalLink, Circle, Monitor } from 'lucide-react';
-import { apiFetch } from '@/lib/api';
+import { apiFetch, ApiError } from '@/lib/api';
 import { useLocale } from '@/lib/LocaleContext';
 
 interface MindosDesktopBridge {
@@ -387,7 +387,13 @@ function BrowserUpdateTab() {
 
     try {
       await apiFetch('/api/update', { method: 'POST' });
-    } catch {
+    } catch (err) {
+      if (err instanceof ApiError) {
+        localStorage.removeItem(UPDATE_STATE_KEY);
+        setUpdateError(err.message || 'Update failed');
+        setState('error');
+        return;
+      }
       // Expected — server may die during update
     }
 


### PR DESCRIPTION
Closes #10.

### Summary

This change fixes immediate failure handling in the browser update flow.

Before this patch, an immediate API failure from `POST /api/update` was treated like a normal update handoff followed by server restart. As a result, the UI stayed in the long-running updating state even when the update never actually started.

### Changes

- treat immediate `ApiError` failures from `/api/update` as real startup failures
- clear persisted `mindos_update_in_progress` state before entering the error path
- surface the error state so the retry action becomes available
- add focused browser regression coverage for the failure path

### Rationale

There are two distinct cases in the browser update flow:

1. the update process starts and the server may temporarily disappear
2. the update request fails immediately and no restart ever begins

Only the first case should continue into polling/recovery mode. The second case should fail fast and give the user a retry path.

### Verification

Bug validation:

1. Focused browser tests reproduced that an immediate `/api/update` failure left the UI in the updating state instead of surfacing a retry path.
2. The same scenario left `mindos_update_in_progress` in localStorage, proving that failure cleanup was incomplete.

Fix validation:

1. Focused browser update regression tests now pass.
2. The full app test suite passes after the change.

### Tests

```bash
npx vitest run /Users/urara/Code/MindOS/app/__tests__/settings/update-tab-browser.test.tsx --config vitest.config.ts
npx vitest run
```
