### PR TITLE
fix: detect external tree changes in tree-version

### DIFF
--- a/app/__tests__/api/tree-version.test.ts
+++ b/app/__tests__/api/tree-version.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let tempRoot: string;
+
+beforeEach(() => {
+  tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mindos-tree-version-test-'));
+  vi.resetModules();
+  vi.doMock('@/lib/settings', () => ({
+    effectiveSopRoot: () => tempRoot,
+  }));
+});
+
+afterEach(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('GET /api/tree-version', () => {
+  it('bumps after an external file is added once the cache becomes stale', async () => {
+    const fsLib = await import('@/lib/fs');
+    const route = await import('@/app/api/tree-version/route');
+
+    fsLib.getFileTree(); // warm empty cache
+    const before = await route.GET();
+    expect((await before.json()).v).toBe(0);
+
+    fs.writeFileSync(path.join(tempRoot, 'external.md'), '# external', 'utf-8');
+    await new Promise((r) => setTimeout(r, 5100));
+
+    const after = await route.GET();
+    expect((await after.json()).v).toBe(1);
+  }, 12_000);
+
+  it('does not bump when the file list is unchanged across a stale-cache refresh', async () => {
+    const fsLib = await import('@/lib/fs');
+    const route = await import('@/app/api/tree-version/route');
+
+    fs.writeFileSync(path.join(tempRoot, 'existing.md'), '# one', 'utf-8');
+    fsLib.invalidateCache();
+    await route.GET(); // baseline after warming
+    await new Promise((r) => setTimeout(r, 5100));
+
+    const after = await route.GET();
+    expect((await after.json()).v).toBe(1);
+  }, 12_000);
+});

--- a/app/lib/fs.ts
+++ b/app/lib/fs.ts
@@ -59,9 +59,35 @@ const CACHE_TTL_MS = 5_000; // 5 seconds
 
 let _treeVersion = 0;
 
+function buildCache(root: string): FileTreeCache {
+  const tree = buildFileTree(root);
+  const allFiles: string[] = [];
+  function collect(nodes: FileNode[]) {
+    for (const n of nodes) {
+      if (n.type === 'file') allFiles.push(n.path);
+      else if (n.children) collect(n.children);
+    }
+  }
+  collect(tree);
+  return { tree, allFiles, timestamp: Date.now() };
+}
+
+function sameFileList(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((p, i) => p === b[i]);
+}
+
 /** Monotonically increasing counter — bumped on every file mutation so the
  *  client can cheaply detect changes without rebuilding the full tree. */
 export function getTreeVersion(): number {
+  if (_cache && !isCacheValid()) {
+    const next = buildCache(getMindRoot());
+    const changed = !sameFileList(_cache.allFiles, next.allFiles);
+    _cache = next;
+    // External changes can stale the app search index even when the tree shape
+    // is unchanged, so force it to rebuild lazily on the next search.
+    _searchIndex = null;
+    if (changed) _treeVersion++;
+  }
   return _treeVersion;
 }
 
@@ -80,17 +106,7 @@ export function invalidateCache(): void {
 function ensureCache(): FileTreeCache {
   if (isCacheValid()) return _cache!;
   const root = getMindRoot();
-  const tree = buildFileTree(root);
-  // Extract all file paths from the tree to avoid a second full traversal.
-  const allFiles: string[] = [];
-  function collect(nodes: FileNode[]) {
-    for (const n of nodes) {
-      if (n.type === 'file') allFiles.push(n.path);
-      else if (n.children) collect(n.children);
-    }
-  }
-  collect(tree);
-  _cache = { tree, allFiles, timestamp: Date.now() };
+  _cache = buildCache(root);
   return _cache;
 }
 
@@ -588,4 +604,3 @@ export function findBacklinks(targetPath: string): BacklinkEntry[] {
   const { allFiles } = ensureCache();
   return coreFindBacklinks(getMindRoot(), targetPath, allFiles);
 }
-


### PR DESCRIPTION
### Summary

This change fixes stale file-tree refresh behavior after external disk writes.

Before this patch, the app only refreshed the sidebar tree when `/api/tree-version` changed, but that version only moved when `invalidateCache()` was called in-process. As a result, files created by external CLI tools or agent processes could become visible to server-side file APIs while the sidebar refresh trigger remained flat.

### Changes

- rebuild the cached tree snapshot when `getTreeVersion()` is queried after cache expiry
- bump the tree version when the file list has changed externally
- clear the app search index on this refresh path so search does not keep a stale in-memory index after external writes
- add focused regression coverage for tree-version behavior after external writes

### Why this matters

This is a core product bug, not a cosmetic one.

MindOS is designed to share the same local knowledge base with external tools and agents. If external writes do not advance the tree version, the main file tree can stay stale even though the backend can already see the new files.

### Validation

Bug validation:

1. Static chain validation showed that `SidebarLayout` only refreshes on `/api/tree-version` changes, while the old `getTreeVersion()` only changed on in-process invalidation.
2. A clean-main reproduction showed that `/api/tree-version` stayed at `0` after a direct external disk write.
3. A contrast check showed that after cache expiry `/api/files` could already see the new file while `/api/tree-version` was still unchanged.

Fix validation:

1. Focused `tree-version` tests now pass.
2. Related `files`, `recent-files`, and `search` API tests pass.
3. The full app test suite passes after the change.

### Tests

```bash
npx vitest run __tests__/api/tree-version.test.ts __tests__/api/files.test.ts __tests__/api/recent-files.test.ts __tests__/api/search.test.ts --config vitest.config.ts
npx vitest run
```
