### PR TITLE
fix: persist walkthrough guide state

### DIFF
--- a/app/__tests__/api/setup-walkthrough.test.ts
+++ b/app/__tests__/api/setup-walkthrough.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let tempHome: string;
+let configPath: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mindos-guide-test-'));
+  savedHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  configPath = path.join(tempHome, '.mindos', 'config.json');
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({
+    ai: {
+      provider: 'anthropic',
+      providers: {
+        anthropic: { apiKey: '', model: 'claude-sonnet-4-6' },
+        openai: { apiKey: '', model: 'gpt-5.4', baseUrl: '' },
+      },
+    },
+    mindRoot: '/tmp/mind',
+    guideState: {
+      active: true,
+      dismissed: false,
+      template: 'en',
+      step1Done: false,
+      askedAI: false,
+      nextStepIndex: 0,
+    },
+  }));
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = savedHome;
+  fs.rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('PATCH /api/setup walkthrough persistence', () => {
+  it('persists walkthrough fields into an existing active guideState', async () => {
+    const route = await import('@/app/api/setup/route');
+
+    const req = new NextRequest('http://localhost/api/setup', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        guideState: {
+          walkthroughStep: 2,
+          walkthroughDismissed: true,
+        },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const res = await route.PATCH(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.guideState.walkthroughStep).toBe(2);
+    expect(body.guideState.walkthroughDismissed).toBe(true);
+  });
+
+  it('returns walkthrough fields in the PATCH response for an active guideState', async () => {
+    const route = await import('@/app/api/setup/route');
+
+    const patchReq = new NextRequest('http://localhost/api/setup', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        guideState: {
+          walkthroughStep: 1,
+          walkthroughDismissed: false,
+        },
+      }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await route.PATCH(patchReq);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.guideState.walkthroughStep).toBe(1);
+    expect(body.guideState.walkthroughDismissed).toBe(false);
+  });
+
+  it('route and settings source both explicitly preserve walkthrough fields', async () => {
+    const routeSource = fs.readFileSync('/tmp/mindos-fix-walkthrough-XyNOJw/app/app/api/setup/route.ts', 'utf-8');
+    const settingsSource = fs.readFileSync('/tmp/mindos-fix-walkthrough-XyNOJw/app/lib/settings.ts', 'utf-8');
+
+    expect(routeSource).toContain('patch.walkthroughStep');
+    expect(routeSource).toContain('patch.walkthroughDismissed');
+    expect(settingsSource).toContain('typeof obj.walkthroughDismissed === \'boolean\' ? obj.walkthroughDismissed : undefined');
+  });
+});

--- a/app/app/api/setup/route.ts
+++ b/app/app/api/setup/route.ts
@@ -172,6 +172,8 @@ export async function PATCH(req: NextRequest) {
     if (typeof patch.askedAI === 'boolean') updated.askedAI = patch.askedAI;
     if (typeof patch.nextStepIndex === 'number' && patch.nextStepIndex >= 0) updated.nextStepIndex = patch.nextStepIndex;
     if (typeof patch.active === 'boolean') updated.active = patch.active;
+    if (typeof patch.walkthroughStep === 'number' && patch.walkthroughStep >= 0) updated.walkthroughStep = patch.walkthroughStep;
+    if (typeof patch.walkthroughDismissed === 'boolean') updated.walkthroughDismissed = patch.walkthroughDismissed;
 
     writeSettings({ ...current, guideState: updated });
     return NextResponse.json({ ok: true, guideState: updated });

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -148,7 +148,7 @@ function parseGuideState(raw: unknown): GuideState | undefined {
     askedAI: obj.askedAI === true,
     nextStepIndex: typeof obj.nextStepIndex === 'number' ? obj.nextStepIndex : 0,
     walkthroughStep: typeof obj.walkthroughStep === 'number' ? obj.walkthroughStep : undefined,
-    walkthroughDismissed: obj.walkthroughDismissed === true ? true : undefined,
+    walkthroughDismissed: typeof obj.walkthroughDismissed === 'boolean' ? obj.walkthroughDismissed : undefined,
   };
 }
 


### PR DESCRIPTION
### Summary

This change fixes walkthrough persistence through `PATCH /api/setup`.

Before this patch, the walkthrough UI attempted to persist `walkthroughStep` and `walkthroughDismissed`, but the setup PATCH route ignored both fields. As a result, walkthrough progress and dismissal state could not be restored after reload.

### Changes

- persist `walkthroughStep` in the setup PATCH merge path
- persist `walkthroughDismissed` in the setup PATCH merge path
- ensure settings parsing preserves `walkthroughDismissed: false` instead of collapsing it to `undefined`
- add focused regression coverage for walkthrough persistence through `/api/setup`

### Why this matters

This is a first-run/onboarding bug, not an enhancement.

The frontend already relies on persisted walkthrough state to resume or suppress the overlay. If the backend drops those fields, the walkthrough cannot reliably restore its own progress across reloads.

### Validation

Bug validation:

1. Static contract validation showed that `WalkthroughProvider` and `KnowledgeTab` send walkthrough fields, while `PATCH /api/setup` originally ignored them.
2. Route-level validation showed that walkthrough fields were dropped from the PATCH response.
3. State-read validation showed that walkthrough progress could not be recovered through the setup settings path.

Fix validation:

1. Focused `setup-walkthrough` tests now pass.
2. Existing `setup` API tests still pass.
3. The full app test suite passes after the change.

### Tests

```bash
npx vitest run __tests__/api/setup-walkthrough.test.ts __tests__/api/setup.test.ts --config vitest.config.ts
npx vitest run
```
