### PR TITLE
fix: preserve distinct imports with matching size

### DIFF
--- a/app/__tests__/hooks/useFileImport-dedup.test.tsx
+++ b/app/__tests__/hooks/useFileImport-dedup.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+function renderHook<T>(useHook: () => T) {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  const ref: { current: T | null } = { current: null };
+  function Test() { ref.current = useHook(); return null; }
+  return {
+    ref,
+    async mount() { await act(async () => { root.render(<Test />); }); },
+    async unmount() { await act(async () => { root.unmount(); }); },
+  };
+}
+
+describe('useFileImport duplicate handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  it('keeps two distinct files when name and size match but content differs', async () => {
+    const { useFileImport } = await import('@/hooks/useFileImport');
+    const hook = renderHook(() => useFileImport());
+    await hook.mount();
+
+    const fileA = new File(['aaa'], 'report.txt', { type: 'text/plain' });
+    const fileB = new File(['bbb'], 'report.txt', { type: 'text/plain' });
+    expect(fileA.size).toBe(fileB.size);
+    expect(await fileA.text()).not.toBe(await fileB.text());
+
+    await act(async () => {
+      await hook.ref.current!.addFiles([fileA, fileB]);
+    });
+
+    expect(hook.ref.current!.files).toHaveLength(2);
+
+    await hook.unmount();
+  });
+
+  it('sends both files to /api/file/import after selection', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ created: [], skipped: [], errors: [], updatedFiles: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { useFileImport } = await import('@/hooks/useFileImport');
+    const hook = renderHook(() => useFileImport());
+    await hook.mount();
+
+    const fileA = new File(['aaa'], 'report.txt', { type: 'text/plain' });
+    const fileB = new File(['bbb'], 'report.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await hook.ref.current!.addFiles([fileA, fileB]);
+    });
+
+    await act(async () => {
+      await hook.ref.current!.doArchive();
+    });
+
+    const [, init] = fetchMock.mock.calls.find(([url]) => url === '/api/file/import')!;
+    const payload = JSON.parse((init as RequestInit).body as string);
+    expect(payload.files).toHaveLength(2);
+
+    await hook.unmount();
+  });
+});

--- a/app/hooks/useFileImport.ts
+++ b/app/hooks/useFileImport.ts
@@ -105,10 +105,7 @@ export function useFileImport() {
     setFiles(prev => {
       const merged = [...prev];
       for (const f of newFiles) {
-        const isDup = merged.some(m =>
-          m.name === f.name && m.size === f.size
-        );
-        if (!isDup && merged.length < MAX_FILES) merged.push(f);
+        if (merged.length < MAX_FILES) merged.push(f);
       }
       return merged;
     });


### PR DESCRIPTION
### Summary

This change fixes silent client-side loss of distinct files during import.

Before this patch, `useFileImport` deduplicated selected files using only `name + size`. That caused two different files with the same filename and same byte size to collapse into one entry before import even began.

### Changes

- remove the client-side `name + size` deduplication from `useFileImport`
- add focused regression coverage that verifies:
  - two distinct same-name same-size files are both preserved in hook state
  - both files are included in the `/api/file/import` payload

### Why this matters

This is effectively a data-loss bug.

Users can select two distinct files and lose one silently before conflict handling or archive logic ever has a chance to warn them. That is much worse than allowing both files through and letting the explicit import/conflict pipeline resolve collisions visibly.

### Validation

Bug validation:

1. Static analysis showed the old hook deduplicated on `name + size` only.
2. A clean-main reproduction showed that two different files with the same name and same size collapsed to a single selection.
3. A downstream check showed that the `/api/file/import` payload also contained only one file, proving the loss was real and not just visual.

Fix validation:

1. Focused `useFileImport-dedup` tests now pass.
2. The archive payload includes both files after selection.
3. The full app test suite passes after the change.

### Tests

```bash
npx vitest run __tests__/hooks/useFileImport-dedup.test.tsx --config vitest.config.ts
npx vitest run
```
