### PR TITLE
fix: decode &amp; as & instead of space in web_fetch tool

### DIFF
--- a/app/lib/agent/tools.ts
+++ b/app/lib/agent/tools.ts
@@ -543,7 +543,7 @@ export const knowledgeBaseTools: AgentTool<any>[] = [
         
         // Decode common HTML entities
         text = text.replace(/&nbsp;/g, ' ')
-                   .replace(/&amp;/g, ' ')
+                   .replace(/&amp;/g, '&')
                    .replace(/&lt;/g, '<')
                    .replace(/&gt;/g, '>')
                    .replace(/&quot;/g, '"')


### PR DESCRIPTION
## Problem

In `app/lib/agent/tools.ts` line 546, the `web_fetch` tool's HTML entity 
decoding replaces `&amp;` with a space `' '` instead of the correct `&` character.

This causes URLs containing `&` (e.g. query parameters like `?a=1&b=2`) and 
text with ampersands to lose the `&` symbol, replacing it with a space.

## Fix

Changed `.replace(/&amp;/g, ' ')` to `.replace(/&amp;/g, '&')` to correctly 
decode the HTML entity.

## Context

The other HTML entity decodings on adjacent lines (e.g. `&lt;` → `<`, 
`&gt;` → `>`) are all correct — only `&amp;` had the wrong replacement value.
