### PR TITLE
fix: prevent path traversal in CLI file and space commands

### DIFF
--- a/bin/commands/file.js
+++ b/bin/commands/file.js
@@ -22,9 +22,12 @@ function getMindRoot() {
 }
 
 function resolvePath(root, filePath) {
-  // Accept both relative (to mind root) and absolute paths
-  if (filePath.startsWith('/')) return filePath;
-  return resolve(root, filePath);
+  const resolved = resolve(root, filePath);
+  if (!resolved.startsWith(root)) {
+    console.error(red(`Access denied: path outside knowledge base`));
+    process.exit(EXIT.ERROR);
+  }
+  return resolved;
 }
 
 export const meta = {

--- a/bin/commands/space.js
+++ b/bin/commands/space.js
@@ -106,6 +106,10 @@ function countFiles(dir) {
 
 function resolvePath(root, relPath) {
   const full = relPath ? resolve(root, relPath) : root;
+  if (full !== root && !full.startsWith(root + '/')) {
+    console.error(red(`Access denied: path outside knowledge base`));
+    process.exit(EXIT.ERROR);
+  }
   if (!existsSync(full)) {
     console.error(red(`Not found: ${relPath || '(root)'}`));
     process.exit(EXIT.NOT_FOUND);


### PR DESCRIPTION
resolvePath() in file.js accepted absolute paths and did not validate that resolved relative paths stay within MIND_ROOT. This allowed commands like 'mindos file read /etc/passwd' or 'mindos file read ../../etc/passwd' to access files outside the knowledge base.

Added startsWith(root) boundary check in both file.js and space.js to reject any resolved path that escapes MIND_ROOT.