### PR TITLE
fix: correct || true always-true condition and duplicate ACP error code

### DIFF
--- a/app/lib/acp/types.ts
+++ b/app/lib/acp/types.ts
@@ -265,7 +265,7 @@ export const ACP_ERRORS = {
   SPAWN_FAILED: { code: -32004, message: 'Failed to spawn agent process' },
   TRANSPORT_ERROR: { code: -32005, message: 'Transport error' },
   AUTH_REQUIRED: { code: -32000, message: 'Authentication required' },
-  RESOURCE_NOT_FOUND: { code: -32002, message: 'Resource not found' },
+  RESOURCE_NOT_FOUND: { code: -32006, message: 'Resource not found' },
   PARSE_ERROR: { code: -32700, message: 'Parse error' },
   INVALID_REQUEST: { code: -32600, message: 'Invalid request' },
   METHOD_NOT_FOUND: { code: -32601, message: 'Method not found' },

--- a/bin/commands/file.js
+++ b/bin/commands/file.js
@@ -128,7 +128,7 @@ function walkFiles(dir, root, opts = {}) {
 
 function fileList(root, _args, flags) {
   const files = walkFiles(root, root, {
-    recursive: flags.recursive || flags.r || true,
+    recursive: flags.recursive ?? flags.r ?? true,
     space: flags.space || null,
   });
 


### PR DESCRIPTION
1. bin/commands/file.js: 'flags.recursive || flags.r || true' always evaluates to true, making the --recursive/-r flag ineffective. Changed || to ?? so the flag defaults to true only when not provided.

2. app/lib/acp/types.ts: SESSION_BUSY and RESOURCE_NOT_FOUND both used error code -32002, making them indistinguishable for clients. Changed RESOURCE_NOT_FOUND to -32006 to give it a unique code.