### PR TITLE
fix(web): keep agent turn SSE stream alive

### DIFF
--- a/packages/web/__tests__/api/agent-turn-sse.test.ts
+++ b/packages/web/__tests__/api/agent-turn-sse.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createAgentTurnSseResponse } from '../../app/api/agent/_lib/turn-sse';
+
+describe('agent turn SSE response', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits hidden status heartbeat data frames while the agent is quiet', async () => {
+    vi.useFakeTimers();
+    const response = createAgentTurnSseResponse(async () => {
+      await new Promise(() => {});
+    });
+    const reader = response.body!.getReader();
+
+    const read = reader.read();
+    await vi.advanceTimersByTimeAsync(15_000);
+    const chunk = await read;
+
+    expect(chunk.done).toBe(false);
+    const text = new TextDecoder().decode(chunk.value);
+    expect(text).toBe('data:{"type":"status","visible":false,"message":"keep-alive"}\n\n');
+
+    await reader.cancel();
+  });
+});

--- a/packages/web/app/api/agent/_lib/turn-sse.ts
+++ b/packages/web/app/api/agent/_lib/turn-sse.ts
@@ -8,6 +8,13 @@ import type { AgentRunRecord } from '@geminilight/mindos/agent/ledger/run-ledger
 import { isAbortLikeError } from '@geminilight/mindos/agent/ledger/run-cancellation';
 import { metrics } from '@/lib/metrics';
 
+const AGENT_TURN_SSE_HEARTBEAT_MS = 15_000;
+const AGENT_TURN_SSE_HEARTBEAT_EVENT: MindOSSSEvent = {
+  type: 'status',
+  visible: false,
+  message: 'keep-alive',
+};
+
 export function agentRunErrorStatus(error: unknown, signal?: AbortSignal): 'failed' | 'canceled' | 'timed_out' {
   if (signal?.aborted || isAbortLikeError(error)) return 'canceled';
   return (error as { code?: unknown })?.code === 'TIMEOUT' ? 'timed_out' : 'failed';
@@ -65,20 +72,37 @@ export function createAgentTurnSseResponse(
 ): Response {
   const encoder = new TextEncoder();
   const requestStartTime = Date.now();
+  let streamClosed = false;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  function markStreamClosed() {
+    streamClosed = true;
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
+  }
   const stream = new ReadableStream({
     start(controller) {
-      let streamClosed = false;
+      heartbeatTimer = setInterval(() => {
+        if (streamClosed) return;
+        try {
+          controller.enqueue(encoder.encode(encodeMindosSseEvent(AGENT_TURN_SSE_HEARTBEAT_EVENT)));
+        } catch {
+          markStreamClosed();
+        }
+      }, AGENT_TURN_SSE_HEARTBEAT_MS);
+
       function send(event: MindOSSSEvent) {
         if (streamClosed) return;
         try {
           controller.enqueue(encoder.encode(encodeMindosSseEvent(event)));
         } catch {
-          streamClosed = true;
+          markStreamClosed();
         }
       }
       function safeClose() {
         if (streamClosed) return;
-        streamClosed = true;
+        markStreamClosed();
         try { controller.close(); } catch { /* already closed */ }
       }
 
@@ -91,6 +115,9 @@ export function createAgentTurnSseResponse(
         send({ type: 'error', message: fallbackErrorMessage(err) });
         safeClose();
       });
+    },
+    cancel() {
+      markStreamClosed();
     },
   });
 


### PR DESCRIPTION
Summary:
- add a hidden SSE status heartbeat during quiet agent turns
- clear the heartbeat timer when the stream closes or is canceled
- add Vitest coverage for quiet agent turn streams

Testing:
- pnpm --dir /root/MindOS/packages/web exec vitest run __tests__/api/agent-turn-sse.test.ts
- pre-push hook: related Vitest tests and @mindos/web typecheck