### PR TITLE
Fix update check version resolution

### DIFF
--- a/packages/mindos/bin/lib/update-check.js
+++ b/packages/mindos/bin/lib/update-check.js
@@ -9,15 +9,25 @@ const REGISTRIES = [
   'https://registry.npmjs.org/@geminilight/mindos/latest',
 ];
 
-/** Simple semver "a > b" comparison (major.minor.patch only). */
-function semverGt(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
+/** Simple semver comparison (major.minor.patch only). */
+function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return 0;
   for (let i = 0; i < 3; i++) {
-    if ((pa[i] || 0) > (pb[i] || 0)) return true;
-    if ((pa[i] || 0) < (pb[i] || 0)) return false;
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
   }
-  return false;
+  return 0;
+}
+
+function semverGt(a, b) {
+  return compareSemver(a, b) > 0;
+}
+
+function parseSemver(version) {
+  const match = String(version).trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 function getCurrentVersion() {
@@ -46,18 +56,24 @@ function writeCache(latestVersion) {
 }
 
 async function fetchLatest() {
+  const versions = [];
   for (const url of REGISTRIES) {
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
       if (res.ok) {
         const data = await res.json();
-        return data.version;
+        if (typeof data.version === 'string' && data.version) versions.push(data.version);
       }
     } catch {
       continue;
     }
   }
-  return null;
+
+  let latest = null;
+  for (const version of versions) {
+    if (!latest || compareSemver(version, latest) > 0) latest = version;
+  }
+  return latest;
 }
 
 /**
@@ -74,9 +90,8 @@ export async function checkForUpdate() {
   if (cache?.lastCheck) {
     const age = Date.now() - new Date(cache.lastCheck).getTime();
     if (age < TTL_MS) {
-      return (cache.latestVersion && semverGt(cache.latestVersion, current))
-        ? cache.latestVersion
-        : null;
+      if (cache.latestVersion && semverGt(cache.latestVersion, current)) return cache.latestVersion;
+      if (cache.latestVersion && compareSemver(cache.latestVersion, current) === 0) return null;
     }
   }
 

--- a/packages/mindos/src/server.product-ops.test.ts
+++ b/packages/mindos/src/server.product-ops.test.ts
@@ -583,6 +583,39 @@ describe('MindOS server contract: product operations', () => {
       status: 200,
       body: { current: '1.0.0', latest: '1.0.1', hasUpdate: true },
     });
+
+    const projectRoot = mkdtempSync(join(tmpdir(), 'mindos-update-version-'));
+    mkdirSync(join(projectRoot, 'packages', 'mindos'), { recursive: true });
+    writeFileSync(join(projectRoot, 'packages', 'mindos', 'package.json'), JSON.stringify({
+      name: '@geminilight/mindos',
+      version: '1.1.53',
+    }));
+
+    await expect(handleUpdateCheckGet({
+      projectRoot,
+      env: {},
+      registries: [],
+    })).resolves.toMatchObject({
+      status: 200,
+      body: { current: '1.1.53', latest: '1.1.53', hasUpdate: false },
+    });
+
+    await expect(handleUpdateCheckGet({
+      currentVersion: '1.1.53',
+      registries: [
+        'https://registry.npmmirror.example/@geminilight/mindos/latest',
+        'https://registry.npmjs.example/@geminilight/mindos/latest',
+      ],
+      fetcher: async (url) => ({
+        ok: true,
+        json: async () => ({
+          version: url.includes('npmmirror') ? '0.6.33' : '1.1.55',
+        }),
+      }),
+    })).resolves.toMatchObject({
+      status: 200,
+      body: { current: '1.1.53', latest: '1.1.55', hasUpdate: true },
+    });
   });
 
   it('runs restart and update process controls with sanitized child environments', () => {

--- a/packages/mindos/src/server/handlers/update.ts
+++ b/packages/mindos/src/server/handlers/update.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { json, type MindosServerResponse } from '../response.js';
+import { readMindosProductVersion, type VersionResolutionOptions } from './health.js';
 
 export const IDLE_UPDATE_STATUS = {
   stage: 'idle',
@@ -23,7 +24,7 @@ export type UpdateStatusOptions = {
   statusPath?: string;
 };
 
-export type UpdateCheckOptions = {
+export type UpdateCheckOptions = VersionResolutionOptions & {
   currentVersion?: string;
   packageJsonPaths?: string[];
   registries?: string[];
@@ -70,9 +71,10 @@ export function handleUpdateStatusGet(
 export async function handleUpdateCheckGet(
   options: UpdateCheckOptions = {},
 ): Promise<MindosServerResponse<UpdateCheckPayload>> {
-  const current = options.currentVersion ?? readCurrentVersion(options.packageJsonPaths);
+  const current = options.currentVersion ?? readCurrentVersion(options);
   let latest = current;
   const fetcher = options.fetcher ?? defaultFetchLatest;
+  const discoveredVersions: string[] = [];
 
   for (const registry of options.registries ?? DEFAULT_REGISTRIES) {
     try {
@@ -84,8 +86,7 @@ export async function handleUpdateCheckGet(
         const data = await response.json();
         const version = data && typeof data === 'object' ? (data as { version?: unknown }).version : undefined;
         if (typeof version === 'string' && version) {
-          latest = version;
-          break;
+          discoveredVersions.push(version);
         }
       } finally {
         clearTimeout(timer);
@@ -93,6 +94,10 @@ export async function handleUpdateCheckGet(
     } catch {
       continue;
     }
+  }
+
+  for (const version of discoveredVersions) {
+    if (compareSemver(version, latest) > 0) latest = version;
   }
 
   return json({
@@ -126,11 +131,20 @@ export function handleUpdatePost(options: ProcessControlOptions = {}): MindosSer
   }
 }
 
-function readCurrentVersion(packageJsonPaths?: string[]): string {
-  const candidates = packageJsonPaths ?? [
-    ...(process.env.MINDOS_PROJECT_ROOT ? [resolve(process.env.MINDOS_PROJECT_ROOT, 'package.json')] : []),
-    resolve(process.cwd(), '..', 'package.json'),
-  ];
+function readCurrentVersion(options: UpdateCheckOptions): string {
+  const pathVersion = options.packageJsonPaths ? readVersionFromPackageJsonPaths(options.packageJsonPaths) : undefined;
+  if (pathVersion) return pathVersion;
+
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  return readMindosProductVersion({
+    cwd,
+    env,
+    projectRoot: options.projectRoot ?? env.MINDOS_PROJECT_ROOT ?? findWorkspaceRoot(cwd),
+  });
+}
+
+function readVersionFromPackageJsonPaths(candidates: string[]): string | undefined {
   for (const candidate of candidates) {
     try {
       const parsed = JSON.parse(readFileSync(candidate, 'utf-8')) as { version?: unknown };
@@ -139,7 +153,7 @@ function readCurrentVersion(packageJsonPaths?: string[]): string {
       // Try next candidate.
     }
   }
-  return '0.0.0';
+  return undefined;
 }
 
 function spawnCli(command: 'restart' | 'update', childEnv: NodeJS.ProcessEnv, options: ProcessControlOptions): void {

--- a/packages/mindos/src/server/http.ts
+++ b/packages/mindos/src/server/http.ts
@@ -625,7 +625,9 @@ async function handleRequest(
       return;
     }
     if (route === 'GET /api/update-check') {
-      writeResponse(res, await handleUpdateCheckGet());
+      writeResponse(res, await handleUpdateCheckGet({
+        projectRoot: services.runtimeRoot ?? runtimeRoot ?? process.cwd(),
+      }));
       return;
     }
     if (route === 'POST /api/restart') {

--- a/packages/web/app/api/update-check/route.ts
+++ b/packages/web/app/api/update-check/route.ts
@@ -1,8 +1,11 @@
 export const dynamic = 'force-dynamic';
 
 import { handleUpdateCheckGet } from '@geminilight/mindos/server';
+import { getProjectRoot } from '@/lib/project-root';
 import { toNextResponse } from '../_mindos-adapter';
 
+const projectRoot = getProjectRoot();
+
 export async function GET() {
-  return toNextResponse(await handleUpdateCheckGet());
+  return toNextResponse(await handleUpdateCheckGet({ projectRoot }));
 }

--- a/tests/unit/cli-update-check.test.ts
+++ b/tests/unit/cli-update-check.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+let tempDir: string;
+let packageJson: string;
+let updateCheckPath: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mindos-cli-update-check-'));
+  packageJson = path.join(tempDir, 'package.json');
+  updateCheckPath = path.join(tempDir, 'update-check.json');
+  fs.writeFileSync(packageJson, JSON.stringify({ name: '@geminilight/mindos', version: '1.1.53' }));
+
+  vi.resetModules();
+  vi.doMock('../../packages/mindos/bin/lib/constants.js', () => ({
+    PRODUCT_PACKAGE_JSON: packageJson,
+    UPDATE_CHECK_PATH: updateCheckPath,
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('CLI update check', () => {
+  it('ignores stale lower cache and chooses the highest registry version', async () => {
+    fs.writeFileSync(updateCheckPath, JSON.stringify({
+      lastCheck: new Date().toISOString(),
+      latestVersion: '0.6.33',
+    }));
+
+    const fetchMock = vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => ({
+        version: url.includes('npmmirror') ? '0.6.33' : '1.1.55',
+      }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { checkForUpdate } = await import('../../packages/mindos/bin/lib/update-check.js');
+
+    await expect(checkForUpdate()).resolves.toBe('1.1.55');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fs.readFileSync(updateCheckPath, 'utf-8'))).toMatchObject({
+      latestVersion: '1.1.55',
+    });
+  });
+});


### PR DESCRIPTION

<img width="1503" height="522" alt="image" src="https://github.com/user-attachments/assets/375972d6-b12d-4ea2-8f28-111b95d57587" />

<img width="1539" height="550" alt="image" src="https://github.com/user-attachments/assets/5b3add5f-d09d-45ae-96da-ae2e150624ac" />


## Summary
- resolve update-check current version from the MindOS product package instead of falling back to 0.0.0
- compare versions from all configured registries so a stale mirror cannot override a newer npm result
- apply the same highest-version logic to the CLI update cache and add regression coverage

## Tests
- pnpm -C /root/MindOS exec vitest run tests/unit/cli-update-check.test.ts
- pnpm --dir /root/MindOS/packages/mindos exec vitest run src/server.product-ops.test.ts
- pnpm --dir /root/MindOS/packages/mindos exec tsc --noEmit
- pnpm -C /root/MindOS --filter @geminilight/mindos build
- pnpm --dir /root/MindOS/packages/web exec tsc --noEmit
- pnpm -C /root/MindOS/packages/web build