### PR TITLE
fix(web): submit latest agent permission mode

### DIFF
--- a/packages/web/__tests__/ask/ask-content-agent-selection.test.tsx
+++ b/packages/web/__tests__/ask/ask-content-agent-selection.test.tsx
@@ -4,7 +4,7 @@ import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import ChatContent from '@/components/chat/ChatContent';
 import { LAST_AGENT_RUNTIME_STORAGE_KEY } from '@/lib/ask-runtime-preference';
-import type { ChatSession } from '@/lib/types';
+import type { AgentPermissionMode, ChatSession } from '@/lib/types';
 import type { RuntimeSessionEntry } from '@/lib/runtime-session-entry';
 
 const mockSetMessages = vi.fn();
@@ -29,6 +29,7 @@ let mockDetectionLoading = false;
 let mockNativeRuntimeDescriptors: unknown[] = [];
 let mockNativeLoadingByKind: Partial<Record<'codex' | 'claude', boolean>> = {};
 let mockNativeErrorByKind: Partial<Record<'codex' | 'claude', string | null>> = {};
+let mockPersistedPermissionMode: AgentPermissionMode = 'ask';
 
 function isAgentTurnUrl(url: RequestInfo | URL): boolean {
   return String(url).startsWith('/api/agent/sessions/') && String(url).endsWith('/turns');
@@ -395,8 +396,19 @@ vi.mock('@/components/ask/ProviderModelCapsule', () => ({
   getPersistedProviderModel: () => mockPersistedProviderModel,
 }));
 vi.mock('@/components/ask/ModeCapsule', () => ({
-  default: () => null,
-  getPersistedPermissionMode: () => 'ask',
+  default: ({
+    mode,
+    onChange,
+  }: {
+    mode: AgentPermissionMode;
+    onChange: (mode: AgentPermissionMode) => void;
+  }) => (
+    <div data-testid="permission-capsule" data-mode={mode}>
+      <button type="button" onClick={() => onChange('ask')}>Set Ask Permission</button>
+      <button type="button" onClick={() => onChange('full')}>Set Full Permission</button>
+    </div>
+  ),
+  getPersistedPermissionMode: () => mockPersistedPermissionMode,
 }));
 vi.mock('@/lib/utils', () => ({ cn: (...parts: Array<string | false | null | undefined>) => parts.filter(Boolean).join(' ') }));
 vi.mock('@/lib/agent/reconnect', () => ({
@@ -419,6 +431,7 @@ describe('ChatContent ACP session binding', () => {
     mockNativeRuntimeDescriptors = [];
     mockNativeLoadingByKind = {};
     mockNativeErrorByKind = {};
+    mockPersistedPermissionMode = 'ask';
     mockSessions = [sessionWithClaude];
     mockActiveSession = sessionWithClaude;
     mockActiveSessionId = 's1';
@@ -1029,6 +1042,55 @@ describe('ChatContent ACP session binding', () => {
       reasoningEffort: 'high',
     });
     expect(mockSetSessionAgentRuntimeBinding).toHaveBeenCalledWith({ id: 'codex', name: 'Codex', kind: 'codex', binaryPath: '/usr/local/bin/codex' });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('submits the latest full permission mode for a native Codex turn', async () => {
+    mockNativeRuntimeDescriptors = [{
+      id: 'codex',
+      name: 'Codex',
+      kind: 'codex',
+      binaryPath: '/usr/local/bin/codex',
+      status: 'available',
+      capabilities: {},
+    }];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(<ChatContent visible variant="panel" initialMessage="write project notes" />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const selectButton = Array.from(host.querySelectorAll('button')).find((button) => button.textContent === 'Select Codex') as HTMLButtonElement;
+    await act(async () => {
+      selectButton.click();
+    });
+
+    const form = host.querySelector('form') as HTMLFormElement;
+    const fullPermissionButton = Array.from(host.querySelectorAll('button')).find((button) => button.textContent === 'Set Full Permission') as HTMLButtonElement;
+    await act(async () => {
+      fullPermissionButton.click();
+      if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit();
+      } else {
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      }
+    });
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const agentTurnCall = fetchMock.mock.calls.find(([url]) => isAgentTurnUrl(url));
+    expect(agentTurnCall).toBeTruthy();
+    const requestBody = JSON.parse(String((agentTurnCall?.[1] as RequestInit | undefined)?.body));
+    expect(requestBody.selectedRuntime).toEqual({ id: 'codex', name: 'Codex', kind: 'codex', binaryPath: '/usr/local/bin/codex' });
+    expect(requestBody.permissionMode).toBe('full');
 
     await act(async () => {
       root.unmount();

--- a/packages/web/components/chat/ChatContent.tsx
+++ b/packages/web/components/chat/ChatContent.tsx
@@ -210,6 +210,7 @@ export default function ChatContent({ visible, currentFile, initialMessage, init
   const selectedAgentRuntimeRef = useRef(selectedAgentRuntime);
   const pendingOpenAgentRef = useRef<SelectedAgentRuntime | null>(null);
   const [permissionMode, setPermissionMode] = useState<AgentPermissionMode>('ask');
+  const permissionModeRef = useRef<AgentPermissionMode>('ask');
   const [providerOverride, setProviderOverride] = useState<ProviderSelection>(null);
   const providerOverrideRef = useRef<ProviderSelection>(null);
   const [modelOverride, setModelOverride] = useState<string | null>(null);
@@ -235,7 +236,9 @@ export default function ChatContent({ visible, currentFile, initialMessage, init
   const session = useAskSession(currentFile, projectId);
 
   useEffect(() => {
-    setPermissionMode(getPersistedPermissionMode());
+    const persistedPermissionMode = getPersistedPermissionMode();
+    permissionModeRef.current = persistedPermissionMode;
+    setPermissionMode(persistedPermissionMode);
   }, []);
 
   useEffect(() => {
@@ -494,12 +497,13 @@ export default function ChatContent({ visible, currentFile, initialMessage, init
     attachedFilesRef.current = attachedFiles;
     selectedSkillRef.current = selectedSkill;
     selectedAgentRuntimeRef.current = selectedAgentRuntime;
+    permissionModeRef.current = permissionMode;
     sessionRef.current = session;
     uploadRef.current = uploadRuntime;
     imageUploadRef.current = imageUploadRuntime;
     mentionRef.current = mention;
     slashRef.current = slash;
-  }, [attachedFiles, imageUploadRuntime, mention, selectedAgentRuntime, selectedSkill, session, slash, uploadRuntime]);
+  }, [attachedFiles, imageUploadRuntime, mention, permissionMode, selectedAgentRuntime, selectedSkill, session, slash, uploadRuntime]);
 
   useLayoutEffect(() => {
     queuedFollowUpsRef.current = queuedFollowUps;
@@ -549,6 +553,7 @@ export default function ChatContent({ visible, currentFile, initialMessage, init
     selectedSkillRef,
     selectedAgentRuntimeRef,
     attachedFilesRef,
+    permissionModeRef,
   }), []);
   const chat = useAgentChat({
     currentFile,
@@ -1516,6 +1521,11 @@ export default function ChatContent({ visible, currentFile, initialMessage, init
     commitSessionModelSelection(provider, model);
   }, [commitSessionModelSelection]);
 
+  const handlePermissionModeChange = useCallback((next: AgentPermissionMode) => {
+    permissionModeRef.current = next;
+    setPermissionMode(next);
+  }, []);
+
   const handleNativeRuntimeOptionsChange = useCallback((next: NativeRuntimeOptions) => {
     setNativeRuntimeOptions(next);
     const runtime = selectedAgentRuntimeRef.current;
@@ -1945,7 +1955,7 @@ export default function ChatContent({ visible, currentFile, initialMessage, init
                   disabled={isLoading}
                 />
               )}
-              <ModeCapsule mode={permissionMode} onChange={setPermissionMode} disabled={isLoading} />
+              <ModeCapsule mode={permissionMode} onChange={handlePermissionModeChange} disabled={isLoading} />
               {mounted && isAcpRuntime && (
                 <AcpRuntimeOptionsCapsule
                   projection={runtimeSessionProjection.selectedProjection}

--- a/packages/web/hooks/useAgentChat.ts
+++ b/packages/web/hooks/useAgentChat.ts
@@ -84,6 +84,7 @@ export interface AgentChatRefs {
   selectedSkillRef: React.RefObject<{ name: string } | null>;
   selectedAgentRuntimeRef: React.RefObject<(AgentRuntimeIdentity & { binaryPath?: string }) | null>;
   attachedFilesRef: React.RefObject<string[]>;
+  permissionModeRef?: React.RefObject<AgentPermissionMode>;
 }
 
 interface UseAgentChatOpts {
@@ -218,6 +219,7 @@ export function useAgentChat({
     }
 
     const skill = snapshot.skill;
+    const permissionModeSnapshot = refs.permissionModeRef?.current ?? permissionMode;
     const selectedRuntimeBase = compactAgentRuntimeIdentity(refs.selectedAgentRuntimeRef.current);
     const requestRuntimeBase = selectedRuntimeBase?.kind === 'mindos' ? null : selectedRuntimeBase;
     const runtimeSnapshot = selectedRuntimeBase ?? MINDOS_RUNTIME;
@@ -318,7 +320,7 @@ export function useAgentChat({
     const requestBody = JSON.stringify({
       messages: requestMessages,
       agentMode: 'default',
-      permissionMode,
+      permissionMode: permissionModeSnapshot,
       currentFile,
       attachedFiles: snapshot.requestAttachedFiles,
       uploadedFiles: readyUploads


### PR DESCRIPTION
## Summary
- keep the chat permission mode in a ref so a turn submission can read the latest user selection immediately
- pass the permission-mode ref into useAgentChat and snapshot it before building the request body
- add a Codex regression test where the permission mode is changed to full immediately before submitting a native turn

## Verification
- Reproduced on clean origin/main by applying only the regression test: request body kept permissionMode as `ask` instead of `full`.
- `pnpm --dir /root/MindOS/packages/web exec vitest run __tests__/ask/ask-content-agent-selection.test.tsx __tests__/ask/mode-capsule.test.ts`
- `pnpm --dir /root/MindOS/packages/web exec tsc --noEmit`
- pre-push checks passed, including related tests and web typecheck.