### PR TITLE
Fix native runtime reconnect cancellation

### DIFF
--- a/packages/mindos/src/agent/ledger/run-timeline-events.test.ts
+++ b/packages/mindos/src/agent/ledger/run-timeline-events.test.ts
@@ -28,7 +28,7 @@ describe('appendSseEventToAgentRun', () => {
     expect(events.some((event) => event.type === 'runtime_status' && event.message === 'keep-alive')).toBe(false);
   });
 
-  it('keeps native runtime text out of the ledger while preserving actionable status and tool events', () => {
+  it('stores native runtime text as debug replay data while preserving actionable status and tool events', () => {
     const run = startAgentRun({
       id: 'run-native',
       agentKind: 'native-runtime',
@@ -44,7 +44,18 @@ describe('appendSseEventToAgentRun', () => {
     appendSseEventToAgentRun(run.id, { type: 'tool_start', runtime: 'claude', toolCallId: 'tool-1', toolName: 'Bash', args: { command: 'npm test' } });
 
     const events = listAgentEvents({ runId: run.id });
-    expect(events.filter((event) => event.category === 'text')).toEqual([]);
+    expect(events.filter((event) => event.category === 'text')).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        message: 'native text',
+        visibility: 'debug',
+        data: expect.objectContaining({
+          kind: 'text',
+          channel: 'assistant',
+          text: 'native text',
+        }),
+      }),
+    ]);
     expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({
         type: 'runtime_status',
@@ -121,7 +132,7 @@ describe('appendSseEventToAgentRun', () => {
         type: 'permission_requested',
         runtime: 'codex',
         toolCallId: 'tool-1',
-        metadata: { requestId: 'perm-1' },
+        metadata: expect.objectContaining({ requestId: 'perm-1', bridgeRunId: 'run-permission' }),
         data: expect.objectContaining({
           kind: 'permission',
           action: 'command',
@@ -137,7 +148,7 @@ describe('appendSseEventToAgentRun', () => {
       }),
       expect.objectContaining({
         type: 'permission_resolved',
-        metadata: { requestId: 'perm-1' },
+        metadata: expect.objectContaining({ requestId: 'perm-1', bridgeRunId: 'run-permission' }),
         data: expect.objectContaining({
           kind: 'permission',
           status: 'approved',

--- a/packages/mindos/src/agent/ledger/run-timeline-events.ts
+++ b/packages/mindos/src/agent/ledger/run-timeline-events.ts
@@ -4,7 +4,6 @@ import {
 } from '../turn/index.js';
 import {
   appendAgentRunEvent,
-  getAgentRun,
 } from './run-ledger.js';
 import type {
   AgentEventData,
@@ -30,10 +29,6 @@ function safeAuditString(value: unknown): string {
   } catch {
     return redactSensitiveText(String(value));
   }
-}
-
-function isNativeRuntimeRun(runId: string): boolean {
-  return getAgentRun(runId)?.agentKind === 'native-runtime';
 }
 
 function isNativeRuntimeStatus(event: Extract<MindOSSSEvent, { type: 'status' }>): boolean {
@@ -79,7 +74,6 @@ function append(runId: string, input: AppendAgentEventInput): void {
 export function appendSseEventToAgentRun(runId: string, event: MindOSSSEvent): void {
   if (event.type === 'text_delta') {
     if (!event.delta.trim()) return;
-    if (isNativeRuntimeRun(runId)) return;
     append(runId, {
       type: 'text',
       category: 'text',
@@ -91,7 +85,6 @@ export function appendSseEventToAgentRun(runId: string, event: MindOSSSEvent): v
   }
   if (event.type === 'thinking_delta') {
     if (!event.delta.trim()) return;
-    if (isNativeRuntimeRun(runId)) return;
     append(runId, {
       type: 'text',
       category: 'text',
@@ -163,6 +156,7 @@ export function appendSseEventToAgentRun(runId: string, event: MindOSSSEvent): v
       toolName: event.toolName,
       runtime: event.runtime,
       metadata: {
+        bridgeRunId: event.runId,
         requestId: event.requestId,
       },
       data: {
@@ -187,6 +181,7 @@ export function appendSseEventToAgentRun(runId: string, event: MindOSSSEvent): v
       toolCallId: event.toolCallId,
       runtime: event.runtime,
       metadata: {
+        bridgeRunId: event.runId,
         requestId: event.requestId,
       },
       data: {
@@ -208,6 +203,10 @@ export function appendSseEventToAgentRun(runId: string, event: MindOSSSEvent): v
       category: 'question',
       message: 'User question requested',
       toolCallId: event.toolCallId,
+      metadata: {
+        bridgeRunId: event.runId,
+        questions: redactSensitiveObject(event.questions),
+      },
       data: {
         kind: 'question',
         status: 'requested',
@@ -217,11 +216,20 @@ export function appendSseEventToAgentRun(runId: string, event: MindOSSSEvent): v
     return;
   }
   if (event.type === 'user_question_answered' || event.type === 'user_question_cancelled') {
+    const metadata = event.type === 'user_question_answered'
+      ? {
+          bridgeRunId: event.runId,
+          answers: redactSensitiveObject(event.answers ?? []),
+        }
+      : {
+          bridgeRunId: event.runId,
+        };
     append(runId, {
       type: 'user_question_resolved',
       category: 'question',
       message: event.type === 'user_question_cancelled' ? event.reason : 'User answered',
       toolCallId: event.toolCallId,
+      metadata,
       data: {
         kind: 'question',
         status: event.type === 'user_question_cancelled' ? 'cancelled' : 'answered',

--- a/packages/mindos/src/server.runtime-web.test.ts
+++ b/packages/mindos/src/server.runtime-web.test.ts
@@ -232,6 +232,11 @@ describe('MindOS server contract: runtime, agent turn stream, static web', () =>
       now: () => Date.parse('2026-06-09T00:00:00.000Z'),
       readSettings: () => ({ acpAgents: {} }),
       checkNativeRuntimeHealth: async () => ({ status: 'available' }),
+      resolveRuntimeCommand: async (command) => {
+        if (command === 'codex') return '/usr/local/bin/codex';
+        if (command === 'claude') return '/usr/local/bin/claude';
+        return null;
+      },
       detectLocalAcpAgents: async () => ({
         installed: [
           { id: 'codex-acp', name: 'Codex', binaryPath: '/usr/local/bin/codex' },

--- a/packages/mindos/src/server/route-ownership.ts
+++ b/packages/mindos/src/server/route-ownership.ts
@@ -72,6 +72,8 @@ export const MINDOS_WEB_API_ROUTE_OWNERSHIP: MindosWebApiRouteOwnership[] = [
   migrated('/api/acp/session', 'high'),
   migrated('/api/agent-activity'),
   host('/api/agent-runs', 'Agent run timeline state is currently stored in the Web host ledger and should stay classified until Product Server owns run persistence.', 'medium'),
+  host('/api/agent-runs/cancel', 'Agent run cancellation dispatches to Web host in-process cancellation handlers and must stay host-owned until Product Server owns run execution control.', 'high'),
+  host('/api/agent-runs/reattach', 'Agent run reattach streams replay Web host in-memory ledger events and must stay host-owned until Product Server owns run persistence and event fanout.', 'medium'),
   host('/api/agent-runs/stream', 'Agent run timeline streaming subscribes to the Web host in-process ledger and must stay host-owned until Product Server owns run persistence and event fanout.', 'medium'),
   host('/api/assistant-runs', 'Assistant run execution currently normalizes assistant requests and delegates into the Web Ask runner; Product Server owns the profile registry only until Runtime Context and Schedule persistence are promoted.', 'medium'),
   migrated('/api/assistants', 'medium'),

--- a/packages/web/__tests__/api/agent-runs-reattach.test.ts
+++ b/packages/web/__tests__/api/agent-runs-reattach.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GET } from '@/app/api/agent-runs/reattach/route';
+import {
+  appendAgentRunEvent,
+  completeAgentRun,
+  resetAgentRunsForTest,
+  startAgentRun,
+} from '@geminilight/mindos/agent/ledger/run-ledger';
+
+type MindosEvent = { type: string; [key: string]: unknown };
+
+class MindosSseReader {
+  private readonly reader: ReadableStreamDefaultReader<Uint8Array>;
+  private readonly decoder = new TextDecoder();
+  private buffer = '';
+  private readonly queue: MindosEvent[] = [];
+
+  constructor(response: Response) {
+    if (!response.body) throw new Error('missing stream body');
+    this.reader = response.body.getReader();
+  }
+
+  async nextMatching(predicate: (event: MindosEvent) => boolean): Promise<MindosEvent> {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const queued = this.shiftMatching(predicate);
+      if (queued) return queued;
+
+      const result = await Promise.race([
+        this.reader.read(),
+        new Promise<ReadableStreamReadResult<Uint8Array>>((_, reject) => {
+          setTimeout(() => reject(new Error('timed out waiting for SSE event')), 1000);
+        }),
+      ]);
+      if (result.done) break;
+      this.buffer += this.decoder.decode(result.value, { stream: true });
+      this.drainBuffer();
+    }
+    throw new Error('matching SSE event was not emitted');
+  }
+
+  async readAll(): Promise<MindosEvent[]> {
+    while (true) {
+      const result = await this.reader.read();
+      if (result.done) break;
+      this.buffer += this.decoder.decode(result.value, { stream: true });
+      this.drainBuffer();
+    }
+    return [...this.queue];
+  }
+
+  async cancel(): Promise<void> {
+    await this.reader.cancel();
+  }
+
+  private shiftMatching(predicate: (event: MindosEvent) => boolean): MindosEvent | undefined {
+    const index = this.queue.findIndex(predicate);
+    if (index < 0) return undefined;
+    const [event] = this.queue.splice(index, 1);
+    return event;
+  }
+
+  private drainBuffer(): void {
+    let boundary = this.buffer.indexOf('\n\n');
+    while (boundary >= 0) {
+      const block = this.buffer.slice(0, boundary);
+      this.buffer = this.buffer.slice(boundary + 2);
+      const data = block
+        .split('\n')
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice('data:'.length).trim())
+        .join('\n');
+      if (data) this.queue.push(JSON.parse(data) as MindosEvent);
+      boundary = this.buffer.indexOf('\n\n');
+    }
+  }
+}
+
+describe('/api/agent-runs/reattach', () => {
+  beforeEach(() => {
+    resetAgentRunsForTest();
+  });
+
+  it('replays existing assistant text and closes completed runs with done', async () => {
+    const run = startAgentRun({
+      agentKind: 'native-runtime',
+      runtimeId: 'codex',
+      displayName: 'Codex',
+      chatSessionId: 'chat-reattach',
+      permissionMode: 'ask',
+      inputSummary: 'Recover',
+    });
+    appendAgentRunEvent(run.id, {
+      type: 'text',
+      category: 'text',
+      data: { kind: 'text', channel: 'assistant', text: 'hello ' },
+      visibility: 'debug',
+    });
+    appendAgentRunEvent(run.id, {
+      type: 'text',
+      category: 'text',
+      data: { kind: 'text', channel: 'assistant', text: 'again' },
+      visibility: 'debug',
+    });
+    completeAgentRun(run.id, { outputSummary: 'hello again' });
+
+    const response = await GET(new Request(`http://localhost/api/agent-runs/reattach?chatSessionId=chat-reattach&rootRunId=${run.id}`));
+    const events = await new MindosSseReader(response).readAll();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream');
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'agent_run_context', rootRunId: run.id }),
+      { type: 'text_delta', delta: 'hello ' },
+      { type: 'text_delta', delta: 'again' },
+      { type: 'done' },
+    ]);
+  });
+
+  it('streams live ledger events for a running run until it reaches a terminal state', async () => {
+    const abort = new AbortController();
+    const run = startAgentRun({
+      agentKind: 'native-runtime',
+      runtimeId: 'claude',
+      displayName: 'Claude Code',
+      chatSessionId: 'chat-live-reattach',
+      permissionMode: 'ask',
+      inputSummary: 'Keep going',
+    });
+
+    const response = await GET(new Request(`http://localhost/api/agent-runs/reattach?chatSessionId=chat-live-reattach&rootRunId=${run.id}`, { signal: abort.signal }));
+    const stream = new MindosSseReader(response);
+    await stream.nextMatching((event) => event.type === 'agent_run_context');
+
+    appendAgentRunEvent(run.id, {
+      type: 'text',
+      category: 'text',
+      data: { kind: 'text', channel: 'assistant', text: 'live chunk' },
+      visibility: 'debug',
+    });
+    const textEvent = await stream.nextMatching((event) => event.type === 'text_delta');
+    completeAgentRun(run.id, { outputSummary: 'live chunk' });
+    const doneEvent = await stream.nextMatching((event) => event.type === 'done');
+    abort.abort();
+    await stream.cancel().catch(() => undefined);
+
+    expect(textEvent).toEqual({ type: 'text_delta', delta: 'live chunk' });
+    expect(doneEvent).toEqual({ type: 'done' });
+  });
+
+  it('replays bridge run ids for pending runtime permission events', async () => {
+    const run = startAgentRun({
+      agentKind: 'native-runtime',
+      runtimeId: 'codex',
+      displayName: 'Codex',
+      chatSessionId: 'chat-permission-reattach',
+      permissionMode: 'ask',
+      inputSummary: 'Needs approval',
+    });
+    appendAgentRunEvent(run.id, {
+      type: 'permission_requested',
+      category: 'permission',
+      runtime: 'codex',
+      toolCallId: 'tool-1',
+      toolName: 'Bash',
+      metadata: {
+        bridgeRunId: 'bridge-run-1',
+        requestId: 'perm-1',
+      },
+      data: {
+        kind: 'permission',
+        action: 'command',
+        status: 'requested',
+        requestId: 'perm-1',
+        resource: 'npm test',
+        options: [{ id: 'accept', label: 'Allow once', intent: 'allow', scope: 'once' }],
+      },
+    });
+    completeAgentRun(run.id);
+
+    const response = await GET(new Request(`http://localhost/api/agent-runs/reattach?chatSessionId=chat-permission-reattach&rootRunId=${run.id}`));
+    const events = await new MindosSseReader(response).readAll();
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'runtime_permission_request',
+      runId: 'bridge-run-1',
+      requestId: 'perm-1',
+      toolCallId: 'tool-1',
+    }));
+  });
+});

--- a/packages/web/__tests__/api/agent-turn-native-runtime.test.ts
+++ b/packages/web/__tests__/api/agent-turn-native-runtime.test.ts
@@ -194,6 +194,15 @@ async function POST(req: NextRequest): Promise<Response> {
   return route.POST(req, { params: Promise.resolve({ sessionId: sessionIdFromRequest(req) }) });
 }
 
+async function POST_CANCEL(body: unknown): Promise<Response> {
+  const route = await import('../../app/api/agent-runs/cancel/route');
+  return route.POST(new Request('http://localhost/api/agent-runs/cancel', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  }));
+}
+
 function sessionIdFromBody(body: unknown): string {
   if (body && typeof body === 'object' && !Array.isArray(body)) {
     const sessionId = (body as { chatSessionId?: unknown }).chatSessionId;
@@ -854,9 +863,19 @@ describe('/api/agent/sessions/:sessionId/turns native runtime routing', () => {
     }));
 
     expect(res.status).toBe(200);
+    await res.text();
     const run = listAgentRuns({ kind: 'native-runtime' })[0]!;
     const events = listAgentEvents({ runId: run.id });
-    expect(events.filter((event) => event.category === 'text')).toEqual([]);
+    expect(events.filter((event) => event.category === 'text')).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kind: 'text',
+          channel: 'assistant',
+        }),
+        visibility: 'debug',
+      }),
+    ]));
+    expect(events.filter((event) => event.category === 'text').every((event) => event.visibility === 'debug')).toBe(true);
     expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({
         type: 'runtime_status',
@@ -879,6 +898,86 @@ describe('/api/agent/sessions/:sessionId/turns native runtime routing', () => {
       category: 'tool',
     }));
     expect(toolEvent).not.toHaveProperty('visibility');
+  });
+
+  it('does not abort the native runtime when the HTTP request signal aborts', async () => {
+    mockResolveCommandPath.mockImplementation(async (command: string) => command === 'codex' ? '/usr/local/bin/codex' : null);
+    mockCheckNativeRuntimeHealth.mockResolvedValue({ status: 'available' });
+    mockDetectLocalAcpAgents.mockResolvedValue({ installed: [], notInstalled: [] });
+    let finishRuntime: (() => void) | undefined;
+    mockRunMindosNativeAgentTurn.mockImplementationOnce(async (options: MindosNativeAgentTurnOptions) => {
+      capturedNativeOptions = options;
+      options.send({ type: 'text_delta', delta: 'still running' });
+      return await new Promise((resolve) => {
+        finishRuntime = () => {
+          options.send({ type: 'done' });
+          resolve({ externalSessionId: 'thr-http-abort' });
+        };
+      });
+    });
+
+    const requestAbort = new AbortController();
+    const body = {
+      messages: [{ role: 'user', content: 'survive a dropped browser stream' }],
+      selectedRuntime: { id: 'codex', name: 'Codex', kind: 'codex' },
+      chatSessionId: 'chat-http-abort',
+    };
+    const res = await POST(new NextRequest('http://localhost/api/agent/sessions/chat-http-abort/turns', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+      signal: requestAbort.signal,
+    }));
+
+    expect(res.status).toBe(200);
+    expect(capturedNativeOptions?.signal?.aborted).toBe(false);
+    requestAbort.abort();
+    expect(capturedNativeOptions?.signal?.aborted).toBe(false);
+
+    finishRuntime?.();
+    await res.text();
+
+    expect(listAgentRuns({ kind: 'native-runtime' })[0]).toEqual(expect.objectContaining({
+      status: 'completed',
+      outputSummary: 'still running',
+      chatSessionId: 'chat-http-abort',
+    }));
+  });
+
+  it('aborts the native runtime through the explicit agent-run cancel API', async () => {
+    mockResolveCommandPath.mockImplementation(async (command: string) => command === 'codex' ? '/usr/local/bin/codex' : null);
+    mockCheckNativeRuntimeHealth.mockResolvedValue({ status: 'available' });
+    mockDetectLocalAcpAgents.mockResolvedValue({ installed: [], notInstalled: [] });
+    mockRunMindosNativeAgentTurn.mockImplementationOnce(async (options: MindosNativeAgentTurnOptions) => {
+      capturedNativeOptions = options;
+      return await new Promise((resolve) => {
+        options.signal?.addEventListener('abort', () => {
+          resolve({ error: options.signal?.reason instanceof Error ? options.signal.reason : new Error('aborted') });
+        }, { once: true });
+      });
+    });
+
+    const res = await POST(agentTurnRequest({
+      messages: [{ role: 'user', content: 'cancel the backend run' }],
+      selectedRuntime: { id: 'codex', name: 'Codex', kind: 'codex' },
+      chatSessionId: 'chat-explicit-cancel',
+    }));
+    expect(res.status).toBe(200);
+    const run = listAgentRuns({ kind: 'native-runtime' })[0]!;
+
+    const cancelRes = await POST_CANCEL({
+      rootRunId: run.id,
+      chatSessionId: 'chat-explicit-cancel',
+    });
+    expect(cancelRes.status).toBe(200);
+    expect(capturedNativeOptions?.signal?.aborted).toBe(true);
+
+    await res.text();
+    expect(listAgentRuns({ kind: 'native-runtime' })[0]).toEqual(expect.objectContaining({
+      id: run.id,
+      status: 'canceled',
+      error: 'Agent run was stopped by the user.',
+    }));
   });
 
   it('maps readonly permission requests to readonly native runtime mode', async () => {

--- a/packages/web/__tests__/ask/ask-concurrent-sessions.test.tsx
+++ b/packages/web/__tests__/ask/ask-concurrent-sessions.test.tsx
@@ -161,6 +161,8 @@ describe('concurrent chat sessions (useAgentChat × agent-run-store)', () => {
   afterEach(async () => {
     await act(async () => { root.unmount(); });
     host.remove();
+    vi.useRealTimers();
+    localStorage.clear();
     resetWorkspaceTabsForTests();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -327,6 +329,43 @@ describe('concurrent chat sessions (useAgentChat × agent-run-store)', () => {
     expect(bindingWriter).toHaveBeenCalledTimes(1);
   });
 
+  it('reattaches to an existing agent run on retry instead of posting a duplicate turn', async () => {
+    localStorage.setItem('mindos-reconnect-retries', '1');
+    await submitText('a', 'recover this run');
+    expect(harness.captured).toHaveLength(1);
+
+    vi.useFakeTimers();
+    await act(async () => {
+      harness.captured[0].hooks.onAgentRunContext?.({
+        rootRunId: 'run-root-1',
+        chatSessionId: 'a',
+        startedAt: 123,
+      });
+      harness.captured[0].reject(new TypeError('Failed to fetch'));
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(harness.captured).toHaveLength(2);
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/agent/sessions/a/turns');
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'POST' });
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/agent-runs/reattach?chatSessionId=a&rootRunId=run-root-1');
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'GET' });
+
+    await act(async () => {
+      harness.captured[1].onMessage({ role: 'assistant', content: 'recovered answer', timestamp: 1 });
+      harness.captured[1].resolve({ role: 'assistant', content: 'recovered answer', timestamp: 1 });
+    });
+    vi.useRealTimers();
+
+    expect(getRun('a')).toBeNull();
+    expect(getMessages('a')[1].content).toBe('recovered answer');
+  });
+
   it('stop() retracts the pending exchange, restores input, and starts a cooldown', async () => {
     await submitText('a', 'cancel me');
     expect(getMessages('a')).toHaveLength(2);
@@ -349,6 +388,32 @@ describe('concurrent chat sessions (useAgentChat × agent-run-store)', () => {
     expect(getMessages('a')).toHaveLength(0);
     expect(getRun('a')).toBeNull();
     expect(getUnread().has('a')).toBe(false);
+  });
+
+  it('stop() sends an explicit cancel request once an agent run context exists', async () => {
+    await submitText('a', 'cancel backend too');
+    await act(async () => {
+      harness.captured[0].hooks.onAgentRunContext?.({
+        rootRunId: 'run-stop-1',
+        chatSessionId: 'a',
+        startedAt: 123,
+      });
+      chat.stop();
+    });
+
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/agent-runs/cancel');
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({
+      method: 'POST',
+      body: JSON.stringify({ chatSessionId: 'a', rootRunId: 'run-stop-1' }),
+    });
+
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    await act(async () => {
+      harness.captured[0].reject(abortErr);
+    });
+    expect(getRun('a')).toBeNull();
   });
 
   it('stopping one session leaves the other run streaming to completion', async () => {

--- a/packages/web/__tests__/ask/ask-concurrent-sessions.test.tsx
+++ b/packages/web/__tests__/ask/ask-concurrent-sessions.test.tsx
@@ -19,12 +19,12 @@ import type { RuntimeBindingMetadata, AgentRunContextMetadata } from '@/lib/agen
 
 const harness = vi.hoisted(() => {
   interface CapturedRun {
-    onMessage: (msg: { role: 'user' | 'assistant'; content: string; timestamp?: number }) => void;
+    onMessage: (msg: Message) => void;
     hooks: {
       onRuntimeBinding?: (binding: unknown) => void;
       onAgentRunContext?: (context: unknown) => void;
     };
-    resolve: (msg: { role: 'assistant'; content: string; timestamp?: number }) => void;
+    resolve: (msg: Message) => void;
     reject: (err: Error) => void;
     signal: AbortSignal;
     body: string;
@@ -364,6 +364,68 @@ describe('concurrent chat sessions (useAgentChat × agent-run-store)', () => {
 
     expect(getRun('a')).toBeNull();
     expect(getMessages('a')[1].content).toBe('recovered answer');
+  });
+
+  it('preserves visible assistant text while replaying a reattach stream', async () => {
+    localStorage.setItem('mindos-reconnect-retries', '1');
+    await submitText('a', 'recover partial output');
+    expect(harness.captured).toHaveLength(1);
+
+    await act(async () => {
+      harness.captured[0].onMessage({
+        role: 'assistant',
+        content: 'partial answer',
+        parts: [{ type: 'text', text: 'partial answer' }],
+        timestamp: 1,
+      });
+    });
+    expect(getMessages('a')[1].content).toBe('partial answer');
+
+    vi.useFakeTimers();
+    await act(async () => {
+      harness.captured[0].hooks.onAgentRunContext?.({
+        rootRunId: 'run-root-1',
+        chatSessionId: 'a',
+        startedAt: 123,
+      });
+      harness.captured[0].reject(new TypeError('Failed to fetch'));
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(harness.captured).toHaveLength(2);
+
+    await act(async () => {
+      harness.captured[1].onMessage({
+        role: 'assistant',
+        content: '',
+        parts: [{ type: 'reasoning', text: 'still thinking' }],
+        timestamp: 2,
+      });
+    });
+    expect(getMessages('a')[1].content).toBe('partial answer');
+    expect(getMessages('a')[1].parts?.some((part) => part.type === 'text' && part.text === 'partial answer')).toBe(true);
+
+    await act(async () => {
+      harness.captured[1].onMessage({
+        role: 'assistant',
+        content: 'answer plus more',
+        parts: [{ type: 'text', text: 'answer plus more' }],
+        timestamp: 2,
+      });
+      harness.captured[1].resolve({
+        role: 'assistant',
+        content: 'answer plus more',
+        parts: [{ type: 'text', text: 'answer plus more' }],
+        timestamp: 2,
+      });
+    });
+    vi.useRealTimers();
+
+    expect(getRun('a')).toBeNull();
+    expect(getMessages('a')[1].content).toBe('partial answer plus more');
   });
 
   it('stop() retracts the pending exchange, restores input, and starts a cooldown', async () => {

--- a/packages/web/app/api/agent-runs/cancel/route.ts
+++ b/packages/web/app/api/agent-runs/cancel/route.ts
@@ -1,0 +1,45 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { getAgentRun } from '@geminilight/mindos/agent/ledger/run-ledger';
+import { cancelAgentRunTree } from '@geminilight/mindos/agent/ledger/run-cancellation';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'JSON body is required' }, { status: 400 });
+  }
+
+  if (!isRecord(body)) {
+    return NextResponse.json({ error: 'JSON body must be an object' }, { status: 400 });
+  }
+
+  const rootRunId = typeof body.rootRunId === 'string' ? body.rootRunId.trim() : '';
+  if (!rootRunId) {
+    return NextResponse.json({ error: 'rootRunId is required' }, { status: 400 });
+  }
+
+  const record = getAgentRun(rootRunId);
+  const chatSessionId = typeof body.chatSessionId === 'string' ? body.chatSessionId.trim() : '';
+  if (chatSessionId && record?.chatSessionId && record.chatSessionId !== chatSessionId) {
+    return NextResponse.json({ error: 'rootRunId does not belong to this chat session' }, { status: 404 });
+  }
+
+  await cancelAgentRunTree(rootRunId, {
+    reason: 'Agent run was stopped by the user.',
+    metadata: {
+      canceledBy: 'user',
+      source: 'agent-runs-cancel-api',
+      ...(chatSessionId ? { chatSessionId } : {}),
+    },
+  });
+
+  return NextResponse.json({ ok: true, rootRunId });
+}

--- a/packages/web/app/api/agent-runs/reattach/route.ts
+++ b/packages/web/app/api/agent-runs/reattach/route.ts
@@ -1,0 +1,348 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import {
+  listAgentEvents,
+  listAgentRuns,
+  subscribeAgentRunEvents,
+  type AgentEvent,
+  type AgentRunRecord,
+} from '@geminilight/mindos/agent/ledger/run-ledger';
+import {
+  encodeMindosSseEvent,
+  MINDOS_SSE_HEADERS,
+  startMindosAgentTurnSseHeartbeat,
+  type MindOSSSEvent,
+} from '@geminilight/mindos/agent/turn';
+
+const encoder = new TextEncoder();
+const REPLAY_LIMIT = 1000;
+
+function isTerminalStatus(status: AgentRunRecord['status']): boolean {
+  return status === 'completed'
+    || status === 'failed'
+    || status === 'canceled'
+    || status === 'timed_out';
+}
+
+function runtimeKind(value: unknown): 'mindos' | 'acp' | 'codex' | 'claude' | undefined {
+  return value === 'mindos' || value === 'acp' || value === 'codex' || value === 'claude'
+    ? value
+    : undefined;
+}
+
+function permissionRuntime(value: unknown): 'acp' | 'codex' | 'claude' | undefined {
+  return value === 'acp' || value === 'codex' || value === 'claude'
+    ? value
+    : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function eventMatchesFilter(event: AgentEvent, input: {
+  chatSessionId: string;
+  rootRunId: string;
+}): boolean {
+  const record = event.record;
+  if (record.chatSessionId !== input.chatSessionId) return false;
+  return record.rootRunId === input.rootRunId || record.id === input.rootRunId;
+}
+
+function listFilteredRuns(input: {
+  chatSessionId: string;
+  rootRunId: string;
+}): AgentRunRecord[] {
+  return listAgentRuns({
+    chatSessionId: input.chatSessionId,
+    rootRunId: input.rootRunId,
+    limit: 500,
+  });
+}
+
+function terminalEventForRuns(runs: AgentRunRecord[]): MindOSSSEvent | null {
+  if (runs.length === 0 || runs.some((run) => !isTerminalStatus(run.status))) return null;
+  const failed = runs.find((run) => run.status === 'failed' || run.status === 'timed_out' || run.status === 'canceled');
+  if (!failed) return { type: 'done' };
+  return {
+    type: 'error',
+    message: failed.error || (
+      failed.status === 'timed_out'
+        ? 'Agent run timed out.'
+        : failed.status === 'canceled'
+          ? 'Agent run was canceled.'
+          : 'Agent run failed.'
+    ),
+  };
+}
+
+function textEventToMindos(event: AgentEvent): MindOSSSEvent | null {
+  if (event.data?.kind !== 'text') return null;
+  if (!event.data.text) return null;
+  if (event.data.channel === 'reasoning') {
+    return { type: 'thinking_delta', delta: event.data.text };
+  }
+  return { type: 'text_delta', delta: event.data.text };
+}
+
+function toolEventToMindos(event: AgentEvent): MindOSSSEvent | null {
+  const data = event.data?.kind === 'tool' ? event.data : undefined;
+  const toolCallId = event.toolCallId;
+  if (!data || !toolCallId) return null;
+  const runtime = runtimeKind(event.runtime);
+  const toolName = event.toolName || data.name || 'tool';
+  if (event.type === 'tool_started') {
+    return {
+      type: 'tool_start',
+      toolCallId,
+      toolName,
+      args: data.inputSummary ?? event.message ?? {},
+      ...(runtime ? { runtime } : {}),
+    };
+  }
+  if (event.type === 'tool_updated') {
+    return {
+      type: 'tool_delta',
+      toolCallId,
+      toolName,
+      delta: data.outputSummary ?? event.message ?? '',
+      ...(runtime ? { runtime } : {}),
+    };
+  }
+  if (event.type === 'tool_completed') {
+    return {
+      type: 'tool_end',
+      toolCallId,
+      toolName,
+      output: data.error ?? data.outputSummary ?? event.message ?? '',
+      isError: data.status === 'failed',
+      ...(runtime ? { runtime } : {}),
+    };
+  }
+  return null;
+}
+
+function permissionEventToMindos(event: AgentEvent): MindOSSSEvent | null {
+  const data = event.data?.kind === 'permission' ? event.data : undefined;
+  const runtime = permissionRuntime(event.runtime);
+  const toolCallId = event.toolCallId;
+  if (!data || !runtime || !toolCallId) return null;
+  const metadata = asRecord(event.metadata);
+  const requestId = data.requestId || stringValue(metadata?.requestId);
+  const bridgeRunId = stringValue(metadata?.bridgeRunId) ?? event.runId;
+  if (!requestId) return null;
+  if (event.type === 'permission_requested') {
+    return {
+      type: 'runtime_permission_request',
+      runId: bridgeRunId,
+      requestId,
+      runtime,
+      toolCallId,
+      toolName: event.toolName || data.action || 'approval_request',
+      input: {
+        ...(data.resource ? { resource: data.resource } : {}),
+        ...(data.prompt ? { prompt: data.prompt } : {}),
+      },
+      options: data.options ?? [],
+      ...(data.prompt ? { reason: data.prompt } : {}),
+      ...(data.action ? { action: data.action } : {}),
+      ...(data.resource ? { resource: data.resource } : {}),
+      ...(data.risk ? { risk: data.risk } : {}),
+    };
+  }
+  if (event.type === 'permission_resolved') {
+    return {
+      type: 'runtime_permission_resolved',
+      runId: bridgeRunId,
+      requestId,
+      runtime,
+      toolCallId,
+      decision: data.decision ?? '',
+      cancelled: data.status === 'expired',
+      ...(data.decisionLabel ? { decisionLabel: data.decisionLabel } : {}),
+      ...(data.decisionIntent ? { decisionIntent: data.decisionIntent } : {}),
+      ...(data.decisionScope ? { decisionScope: data.decisionScope } : {}),
+    };
+  }
+  return null;
+}
+
+function questionEventToMindos(event: AgentEvent): MindOSSSEvent | null {
+  const data = event.data?.kind === 'question' ? event.data : undefined;
+  const toolCallId = event.toolCallId;
+  if (!data || !toolCallId) return null;
+  const metadata = asRecord(event.metadata);
+  const bridgeRunId = stringValue(metadata?.bridgeRunId) ?? event.runId;
+  if (event.type === 'user_question_started') {
+    return {
+      type: 'user_question_start',
+      runId: bridgeRunId,
+      toolCallId,
+      questions: metadata?.questions ?? data.prompt ?? [],
+    };
+  }
+  if (event.type === 'user_question_resolved' && data.status === 'answered') {
+    return {
+      type: 'user_question_answered',
+      runId: bridgeRunId,
+      toolCallId,
+      answers: metadata?.answers ?? [],
+    };
+  }
+  if (event.type === 'user_question_resolved') {
+    return {
+      type: 'user_question_cancelled',
+      runId: bridgeRunId,
+      toolCallId,
+      reason: data.summary ?? 'cancelled',
+    };
+  }
+  return null;
+}
+
+function eventToMindos(event: AgentEvent): MindOSSSEvent | null {
+  if (event.type === 'text') return textEventToMindos(event);
+  if (event.category === 'tool') return toolEventToMindos(event);
+  if (event.category === 'permission') return permissionEventToMindos(event);
+  if (event.category === 'question') return questionEventToMindos(event);
+  if (event.type === 'runtime_status' && event.message) {
+    return {
+      type: 'status',
+      visible: true,
+      message: event.message,
+      ...(runtimeKind(event.runtime) ? { runtime: runtimeKind(event.runtime) } : {}),
+    };
+  }
+  if (event.category === 'error' && event.message) {
+    return { type: 'error', message: event.message };
+  }
+  return null;
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const chatSessionId = url.searchParams.get('chatSessionId')?.trim();
+  const rootRunId = url.searchParams.get('rootRunId')?.trim();
+  if (!chatSessionId || !rootRunId) {
+    return new Response(JSON.stringify({ error: 'chatSessionId and rootRunId are required' }), {
+      status: 400,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
+
+  const initialRuns = listFilteredRuns({ chatSessionId, rootRunId });
+  const contextRun = initialRuns.find((run) => run.id === rootRunId || run.rootRunId === rootRunId) ?? initialRuns[0];
+  if (!contextRun) {
+    return new Response(JSON.stringify({ error: 'agent run was not found' }), {
+      status: 404,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
+
+  const filter = { chatSessionId, rootRunId };
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      let replaying = true;
+      const queuedLiveEvents: AgentEvent[] = [];
+      const sentEventIds = new Set<string>();
+      let stopHeartbeat: (() => void) | undefined;
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        stopHeartbeat?.();
+        stopHeartbeat = undefined;
+        unsubscribe();
+        req.signal.removeEventListener('abort', close);
+        try {
+          controller.close();
+        } catch {
+          // The client may already have closed the stream.
+        }
+      };
+
+      const send = (event: MindOSSSEvent) => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(encodeMindosSseEvent(event)));
+        } catch {
+          close();
+        }
+      };
+
+      const sendLedgerEvent = (event: AgentEvent) => {
+        if (sentEventIds.has(event.id)) return;
+        sentEventIds.add(event.id);
+        const mindosEvent = eventToMindos(event);
+        if (mindosEvent) send(mindosEvent);
+      };
+
+      const sendTerminalIfReady = () => {
+        const terminal = terminalEventForRuns(listFilteredRuns(filter));
+        if (!terminal) return false;
+        send(terminal);
+        close();
+        return true;
+      };
+
+      const unsubscribe = subscribeAgentRunEvents((event) => {
+        if (!eventMatchesFilter(event, filter)) return;
+        if (replaying) {
+          queuedLiveEvents.push(event);
+          return;
+        }
+        sendLedgerEvent(event);
+        sendTerminalIfReady();
+      });
+
+      send({
+        type: 'agent_run_context',
+        rootRunId,
+        chatSessionId,
+        startedAt: contextRun.startedAt,
+      });
+
+      for (const event of listAgentEvents({
+        chatSessionId,
+        rootRunId,
+        limit: REPLAY_LIMIT,
+      }).reverse()) {
+        sendLedgerEvent(event);
+      }
+
+      replaying = false;
+      for (const event of queuedLiveEvents) {
+        sendLedgerEvent(event);
+      }
+      queuedLiveEvents.length = 0;
+
+      if (!sendTerminalIfReady()) {
+        stopHeartbeat = startMindosAgentTurnSseHeartbeat(send, { onError: close });
+      }
+
+      if (req.signal.aborted) {
+        close();
+      } else {
+        req.signal.addEventListener('abort', close);
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: MINDOS_SSE_HEADERS,
+  });
+}

--- a/packages/web/app/api/agent/_lib/turn-lane-native.ts
+++ b/packages/web/app/api/agent/_lib/turn-lane-native.ts
@@ -21,6 +21,9 @@ import {
   startAgentRun,
 } from '@geminilight/mindos/agent/ledger/run-ledger';
 import {
+  registerAgentRunCancelHandler,
+} from '@geminilight/mindos/agent/ledger/run-cancellation';
+import {
   createClaudePermissionPromptConfig,
   resolveRuntimePermissionBaseUrl,
 } from '@/lib/agent/claude-permission-prompt';
@@ -72,6 +75,12 @@ async function runNativeRuntimeTurn(
       ...(input.assistantId ? { assistantId: input.assistantId } : {}),
     },
   });
+  const nativeRunAbort = new AbortController();
+  const nativeRunSignal = nativeRunAbort.signal;
+  const unregisterCancelHandler = registerAgentRunCancelHandler(nativeRun.id, ({ reason }) => {
+    if (nativeRunSignal.aborted) return;
+    nativeRunAbort.abort(cancelReasonToAbortError(reason));
+  });
   const sendWithLedger = (event: MindOSSSEvent) => {
     if (event.type === 'text_delta') outputSummary += event.delta;
     appendSseEventToAgentRun(nativeRun.id, event);
@@ -101,7 +110,7 @@ async function runNativeRuntimeTurn(
         ...(input.nativeRuntimeOptions.reasoningEffort ? { reasoningEffort: input.nativeRuntimeOptions.reasoningEffort } : {}),
         timeoutMs: resolveMindosAgentTimeoutMs(process.env.MINDOS_AGENT_TIMEOUT_MS),
         ...(input.nativeRuntimeEnv ? { runtimeEnv: input.nativeRuntimeEnv } : {}),
-        signal: input.requestSignal,
+        signal: nativeRunSignal,
         send: sendWithLedger,
         services: {
           ...(nativeRuntime.kind === 'claude' ? {
@@ -121,7 +130,7 @@ async function runNativeRuntimeTurn(
     )));
     if (result.error) {
       failAgentRun(nativeRun.id, {
-        status: agentRunErrorStatus(result.error, input.requestSignal),
+        status: agentRunErrorStatus(result.error, nativeRunSignal),
         error: result.error,
         outputSummary,
         ...(result.externalSessionId ? { archive: { sessionId: result.externalSessionId } } : {}),
@@ -149,12 +158,24 @@ async function runNativeRuntimeTurn(
     });
   } catch (error) {
     failAgentRun(nativeRun.id, {
-      status: agentRunErrorStatus(error, input.requestSignal),
+      status: agentRunErrorStatus(error, nativeRunSignal),
       error,
       outputSummary,
     });
     throw error;
+  } finally {
+    unregisterCancelHandler();
   }
+}
+
+function cancelReasonToAbortError(reason: unknown): Error {
+  if (reason instanceof Error) return reason;
+  const message = typeof reason === 'string' && reason.trim()
+    ? reason
+    : 'Agent run was canceled.';
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
 }
 
 function resolveRuntimePermissionBaseUrlForAgentTurnContext(context: AgentTurnRequestContext): string {

--- a/packages/web/hooks/useAgentChat.ts
+++ b/packages/web/hooks/useAgentChat.ts
@@ -131,6 +131,22 @@ function isWorkDirContextError(error: Error & { httpStatus?: number; issueCode?:
   );
 }
 
+function buildAgentRunReattachEndpoint(chatSessionId: string, rootRunId: string): string {
+  const params = new URLSearchParams({
+    chatSessionId,
+    rootRunId,
+  });
+  return `/api/agent-runs/reattach?${params.toString()}`;
+}
+
+async function cancelAgentRunForSession(chatSessionId: string, rootRunId: string): Promise<void> {
+  await fetch('/api/agent-runs/cancel', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chatSessionId, rootRunId }),
+  });
+}
+
 export function useAgentChat({
   currentFile,
   providerOverride,
@@ -176,6 +192,12 @@ export function useAgentChat({
     // Mark retracted before aborting so the AbortError handler in the run
     // closure (which fires on a later microtask) skips its own cleanup.
     if (pending) updateRun(sessionId, { retracted: true, pendingUserMessage: null });
+    const rootRunId = run.agentRunContext?.rootRunId;
+    if (rootRunId) {
+      void cancelAgentRunForSession(sessionId, rootRunId).catch((err) => {
+        console.warn('[useAgentChat] failed to cancel agent run:', err);
+      });
+    }
     run.controller.abort();
 
     if (pending) {
@@ -355,6 +377,43 @@ export function useAgentChat({
       if (run && run.phase !== phase) updateRun(sessionId, { phase });
     };
 
+    const consumeAgentTurnBody = async (body: ReadableStream<Uint8Array>): Promise<{ finalMessage: Message }> => {
+      setPhase('thinking');
+
+      const finalMessage = await consumeUIMessageStream(
+        body,
+        (msg) => {
+          setPhase('streaming');
+          replaceLastMessage(sessionId, annotateMessageWithAgentRuntime(msg, runtimeForMessage), { requireRun: true });
+        },
+        controller.signal,
+        {
+          onRuntimeBinding: (binding) => {
+            // Late events after the run ended are dropped; the lane is judged
+            // from the submit-time snapshot, NOT the currently selected
+            // runtime — the user may have switched runtimes mid-stream.
+            const run = getRun(sessionId);
+            if (!run) return;
+            const runtime = run.runtimeSnapshot;
+            if (!runtime || runtime.kind !== binding.runtime) return;
+            writeRuntimeBinding(sessionId, runtime, {
+              externalSessionId: binding.externalSessionId,
+              cwd: binding.cwd,
+              status: binding.status,
+              updatedAt: Date.now(),
+            });
+          },
+          onAgentRunContext: (context) => {
+            updateRun(sessionId, { agentRunContext: context });
+          },
+          onContextUsage: (usage) => {
+            writeContextUsage(sessionId, usage);
+          },
+        },
+      );
+      return { finalMessage };
+    };
+
     const doFetch = async (): Promise<{ finalMessage: Message }> => {
       const res = await fetch(buildAgentTurnEndpoint(sessionId), {
         method: 'POST',
@@ -390,40 +449,21 @@ export function useAgentChat({
 
       if (!res.body) throw new Error('No response body');
 
-      setPhase('thinking');
+      return consumeAgentTurnBody(res.body);
+    };
 
-      const finalMessage = await consumeUIMessageStream(
-        res.body,
-        (msg) => {
-          setPhase('streaming');
-          replaceLastMessage(sessionId, annotateMessageWithAgentRuntime(msg, runtimeForMessage), { requireRun: true });
-        },
-        controller.signal,
-        {
-          onRuntimeBinding: (binding) => {
-            // Late events after the run ended are dropped; the lane is judged
-            // from the submit-time snapshot, NOT the currently selected
-            // runtime — the user may have switched runtimes mid-stream.
-            const run = getRun(sessionId);
-            if (!run) return;
-            const runtime = run.runtimeSnapshot;
-            if (!runtime || runtime.kind !== binding.runtime) return;
-            writeRuntimeBinding(sessionId, runtime, {
-              externalSessionId: binding.externalSessionId,
-              cwd: binding.cwd,
-              status: binding.status,
-              updatedAt: Date.now(),
-            });
-          },
-          onAgentRunContext: (context) => {
-            updateRun(sessionId, { agentRunContext: context });
-          },
-          onContextUsage: (usage) => {
-            writeContextUsage(sessionId, usage);
-          },
-        },
-      );
-      return { finalMessage };
+    const doReattach = async (rootRunId: string): Promise<{ finalMessage: Message }> => {
+      const res = await fetch(buildAgentRunReattachEndpoint(sessionId, rootRunId), {
+        method: 'GET',
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new Error(`Reconnect failed (${res.status})`);
+      }
+      if (!res.body) throw new Error('No response body');
+
+      return consumeAgentTurnBody(res.body);
     };
 
     try {
@@ -434,17 +474,22 @@ export function useAgentChat({
 
         if (attempt > 0) {
           updateRun(sessionId, { reconnectAttempt: attempt, phase: 'reconnecting' });
-          replaceLastMessage(
-            sessionId,
-            annotateMessageWithAgentRuntime({ role: 'assistant', content: '', timestamp: Date.now() }, runtimeForMessage),
-            { requireRun: true },
-          );
+          if (!getRun(sessionId)?.agentRunContext?.rootRunId) {
+            replaceLastMessage(
+              sessionId,
+              annotateMessageWithAgentRuntime({ role: 'assistant', content: '', timestamp: Date.now() }, runtimeForMessage),
+              { requireRun: true },
+            );
+          }
           await sleep(retryDelay(attempt - 1), controller.signal);
           setPhase('connecting');
         }
 
         try {
-          const { finalMessage } = await doFetch();
+          const rootRunId = attempt > 0 ? getRun(sessionId)?.agentRunContext?.rootRunId : undefined;
+          const { finalMessage } = rootRunId
+            ? await doReattach(rootRunId)
+            : await doFetch();
           if (!finalMessage.content.trim() && (!finalMessage.parts || finalMessage.parts.length === 0)) {
             replaceLastMessage(
               sessionId,

--- a/packages/web/hooks/useAgentChat.ts
+++ b/packages/web/hooks/useAgentChat.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useCallback, useLayoutEffect } from 'react';
-import type { AcpRuntimeOptions, AgentIdentity, AgentPermissionMode, AgentRuntimeIdentity, Message, ImagePart, LocalAttachment, RuntimeSessionBinding, NativeRuntimeOptions } from '@/lib/types';
+import type { AcpRuntimeOptions, AgentIdentity, AgentPermissionMode, AgentRuntimeIdentity, Message, MessagePart, ImagePart, LocalAttachment, RuntimeSessionBinding, NativeRuntimeOptions } from '@/lib/types';
 import type { ProviderId } from '@/lib/agent/providers';
 import { consumeUIMessageStream } from '@/lib/agent/stream-consumer';
 import { MINDOS_AGENT, annotateMessageWithAgentRuntime, compactAgentRuntimeIdentity, getMatchingRuntimeSessionBinding } from '@/lib/ask-agent';
@@ -137,6 +137,77 @@ function buildAgentRunReattachEndpoint(chatSessionId: string, rootRunId: string)
     rootRunId,
   });
   return `/api/agent-runs/reattach?${params.toString()}`;
+}
+
+function mergeTextByOverlap(existing: string, incoming: string): string {
+  if (!existing) return incoming;
+  if (!incoming) return existing;
+  if (incoming.startsWith(existing)) return incoming;
+  if (existing.startsWith(incoming)) return existing;
+
+  const max = Math.min(existing.length, incoming.length);
+  for (let size = max; size > 0; size--) {
+    if (existing.endsWith(incoming.slice(0, size))) {
+      return existing + incoming.slice(size);
+    }
+  }
+  return existing + incoming;
+}
+
+function nonTextPartKey(part: MessagePart): string {
+  if (part.type === 'tool-call') return `tool:${part.toolCallId}`;
+  if (part.type === 'runtime-status') return `runtime-status:${part.runtime ?? ''}:${part.message}`;
+  if (part.type === 'agent-run-timeline') return `timeline:${part.chatSessionId}:${part.rootRunId ?? ''}:${part.startedAfter ?? ''}`;
+  if (part.type === 'reasoning') return `reasoning:${part.text}`;
+  if (part.type === 'image') return `image:${part.fileName ?? ''}:${part.path ?? ''}`;
+  return `part:${JSON.stringify(part)}`;
+}
+
+function mergeNonTextParts(existingParts?: MessagePart[], incomingParts?: MessagePart[]): MessagePart[] {
+  const merged: MessagePart[] = [];
+  const indexByKey = new Map<string, number>();
+  const add = (part: MessagePart) => {
+    if (part.type === 'text') return;
+    const key = nonTextPartKey(part);
+    const existingIndex = indexByKey.get(key);
+    if (existingIndex !== undefined) {
+      merged[existingIndex] = part;
+      return;
+    }
+    indexByKey.set(key, merged.length);
+    merged.push(part);
+  };
+  existingParts?.forEach(add);
+  incomingParts?.forEach(add);
+  return merged;
+}
+
+function mergeReattachedAssistantMessage(existing: Message | null | undefined, incoming: Message): Message {
+  if (!existing || existing.role !== 'assistant' || incoming.role !== 'assistant') return incoming;
+  const existingContent = existing.content ?? '';
+  const incomingContent = incoming.content ?? '';
+  if (!existingContent) return incoming;
+
+  const mergedContent = mergeTextByOverlap(existingContent, incomingContent);
+  if (mergedContent === incomingContent) return incoming;
+
+  const nonTextParts = mergeNonTextParts(existing.parts, incoming.parts);
+  const parts: MessagePart[] = [
+    { type: 'text', text: mergedContent },
+    ...nonTextParts,
+  ];
+  return {
+    ...incoming,
+    content: mergedContent,
+    timestamp: existing.timestamp ?? incoming.timestamp,
+    parts,
+  };
+}
+
+function lastAssistantMessage(sessionId: string): Message | null {
+  const messages = storeGetMessages(sessionId);
+  const last = messages[messages.length - 1];
+  return last?.role === 'assistant' ? last : null;
 }
 
 async function cancelAgentRunForSession(chatSessionId: string, rootRunId: string): Promise<void> {
@@ -377,14 +448,21 @@ export function useAgentChat({
       if (run && run.phase !== phase) updateRun(sessionId, { phase });
     };
 
-    const consumeAgentTurnBody = async (body: ReadableStream<Uint8Array>): Promise<{ finalMessage: Message }> => {
+    const consumeAgentTurnBody = async (
+      body: ReadableStream<Uint8Array>,
+      opts: { mergeReattachReplay?: boolean } = {},
+    ): Promise<{ finalMessage: Message }> => {
       setPhase('thinking');
 
       const finalMessage = await consumeUIMessageStream(
         body,
         (msg) => {
           setPhase('streaming');
-          replaceLastMessage(sessionId, annotateMessageWithAgentRuntime(msg, runtimeForMessage), { requireRun: true });
+          const annotated = annotateMessageWithAgentRuntime(msg, runtimeForMessage);
+          const next = opts.mergeReattachReplay
+            ? mergeReattachedAssistantMessage(lastAssistantMessage(sessionId), annotated)
+            : annotated;
+          replaceLastMessage(sessionId, next, { requireRun: true });
         },
         controller.signal,
         {
@@ -411,7 +489,11 @@ export function useAgentChat({
           },
         },
       );
-      return { finalMessage };
+      if (!opts.mergeReattachReplay) return { finalMessage };
+      const annotatedFinal = annotateMessageWithAgentRuntime(finalMessage, runtimeForMessage);
+      const mergedFinal = mergeReattachedAssistantMessage(lastAssistantMessage(sessionId), annotatedFinal);
+      replaceLastMessage(sessionId, mergedFinal, { requireRun: true });
+      return { finalMessage: mergedFinal };
     };
 
     const doFetch = async (): Promise<{ finalMessage: Message }> => {
@@ -463,7 +545,7 @@ export function useAgentChat({
       }
       if (!res.body) throw new Error('No response body');
 
-      return consumeAgentTurnBody(res.body);
+      return consumeAgentTurnBody(res.body, { mergeReattachReplay: true });
     };
 
     try {


### PR DESCRIPTION
## Summary
- Decouple native runtime execution from the HTTP/SSE request abort signal so a browser stream disconnect does not cancel Codex/Claude work.
- Add explicit agent-run cancel and reattach SSE endpoints; Stop now cancels the backend run, while retry reattaches to the existing rootRunId instead of posting a duplicate turn.
- Store native assistant text as debug ledger replay data and preserve bridge run ids for permission/user-question replay.
- Preserve already visible assistant output while replaying a reattached stream, so reconnect reasoning/short replay snapshots do not wipe the chat body.
- Fix the runtime availability test fixture so native runtime command resolution is mocked explicitly.

## Tests
- pnpm --dir packages/mindos build
- pnpm --dir packages/mindos exec tsc --noEmit
- pnpm --dir packages/web exec tsc --noEmit
- pnpm --dir packages/web exec vitest run __tests__/api/agent-runs-reattach.test.ts __tests__/api/agent-turn-native-runtime.test.ts __tests__/ask/ask-concurrent-sessions.test.tsx
- pnpm --dir packages/web exec vitest run __tests__/api/agent-runs.test.ts __tests__/api/agent-runs-stream.test.ts
- pnpm --dir packages/mindos exec vitest run src/agent/ledger/run-timeline-events.test.ts src/agent/ledger/run-cancellation.test.ts src/agent/ledger/run-ledger.test.ts
- pnpm --dir packages/web build
- pre-push: @mindos/web related vitest suites passed
- pre-push: @mindos/web typecheck passed
- pre-push: @geminilight/mindos test passed
- pre-push: @geminilight/mindos type-check passed
