### PR TITLE
fix: keep established agent runs attached through disconnects

### DIFF
--- a/packages/web/__tests__/api/agent-runs-reattach.test.ts
+++ b/packages/web/__tests__/api/agent-runs-reattach.test.ts
@@ -116,6 +116,27 @@ describe('/api/agent-runs/reattach', () => {
     ]);
   });
 
+  it('replays the terminal output summary when no text events survived', async () => {
+    const run = startAgentRun({
+      agentKind: 'native-runtime',
+      runtimeId: 'codex',
+      displayName: 'Codex',
+      chatSessionId: 'chat-summary-reattach',
+      permissionMode: 'full',
+      inputSummary: 'Long running task',
+    });
+    completeAgentRun(run.id, { outputSummary: 'The background task completed successfully.' });
+
+    const response = await GET(new Request(`http://localhost/api/agent-runs/reattach?chatSessionId=chat-summary-reattach&rootRunId=${run.id}`));
+    const events = await new MindosSseReader(response).readAll();
+
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'agent_run_context', rootRunId: run.id }),
+      { type: 'text_delta', delta: 'The background task completed successfully.' },
+      { type: 'done' },
+    ]);
+  });
+
   it('streams live ledger events for a running run until it reaches a terminal state', async () => {
     const abort = new AbortController();
     const run = startAgentRun({

--- a/packages/web/__tests__/ask/ask-concurrent-sessions.test.tsx
+++ b/packages/web/__tests__/ask/ask-concurrent-sessions.test.tsx
@@ -366,6 +366,45 @@ describe('concurrent chat sessions (useAgentChat × agent-run-store)', () => {
     expect(getMessages('a')[1].content).toBe('recovered answer');
   });
 
+  it('keeps reattaching established runs after the short reconnect limit is exhausted', async () => {
+    localStorage.setItem('mindos-reconnect-retries', '1');
+    await submitText('a', 'keep this long task alive');
+
+    vi.useFakeTimers();
+    await act(async () => {
+      harness.captured[0].hooks.onAgentRunContext?.({
+        rootRunId: 'run-root-durable',
+        chatSessionId: 'a',
+        startedAt: 123,
+      });
+      harness.captured[0].reject(new TypeError('Failed to fetch'));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(harness.captured).toHaveLength(2);
+
+    await act(async () => {
+      harness.captured[1].reject(new TypeError('Failed to fetch'));
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(harness.captured).toHaveLength(3);
+    expect(getRun('a')).not.toBeNull();
+    expect(vi.mocked(fetch).mock.calls[2][0]).toBe(
+      '/api/agent-runs/reattach?chatSessionId=a&rootRunId=run-root-durable',
+    );
+
+    await act(async () => {
+      harness.captured[2].onMessage({ role: 'assistant', content: 'durable result', timestamp: 1 });
+      harness.captured[2].resolve({ role: 'assistant', content: 'durable result', timestamp: 1 });
+    });
+    vi.useRealTimers();
+
+    expect(getRun('a')).toBeNull();
+    expect(getMessages('a')[1].content).toBe('durable result');
+  });
+
   it('preserves visible assistant text while replaying a reattach stream', async () => {
     localStorage.setItem('mindos-reconnect-retries', '1');
     await submitText('a', 'recover partial output');

--- a/packages/web/app/api/agent-runs/reattach/route.ts
+++ b/packages/web/app/api/agent-runs/reattach/route.ts
@@ -83,6 +83,13 @@ function terminalEventForRuns(runs: AgentRunRecord[]): MindOSSSEvent | null {
   };
 }
 
+function terminalOutputSummaryForRuns(runs: AgentRunRecord[], rootRunId: string): string | null {
+  if (runs.length === 0 || runs.some((run) => !isTerminalStatus(run.status))) return null;
+  const rootRun = runs.find((run) => run.id === rootRunId)
+    ?? runs.find((run) => run.rootRunId === rootRunId && run.outputSummary);
+  return rootRun?.outputSummary?.trim() ? rootRun.outputSummary : null;
+}
+
 function textEventToMindos(event: AgentEvent): MindOSSSEvent | null {
   if (event.data?.kind !== 'text') return null;
   if (!event.data.text) return null;
@@ -259,6 +266,7 @@ export async function GET(req: Request) {
       let replaying = true;
       const queuedLiveEvents: AgentEvent[] = [];
       const sentEventIds = new Set<string>();
+      let sentAssistantText = false;
       let stopHeartbeat: (() => void) | undefined;
 
       const close = () => {
@@ -288,12 +296,23 @@ export async function GET(req: Request) {
         if (sentEventIds.has(event.id)) return;
         sentEventIds.add(event.id);
         const mindosEvent = eventToMindos(event);
-        if (mindosEvent) send(mindosEvent);
+        if (mindosEvent) {
+          if (mindosEvent.type === 'text_delta') sentAssistantText = true;
+          send(mindosEvent);
+        }
       };
 
       const sendTerminalIfReady = () => {
-        const terminal = terminalEventForRuns(listFilteredRuns(filter));
+        const runs = listFilteredRuns(filter);
+        const terminal = terminalEventForRuns(runs);
         if (!terminal) return false;
+        if (!sentAssistantText) {
+          const outputSummary = terminalOutputSummaryForRuns(runs, rootRunId);
+          if (outputSummary) {
+            send({ type: 'text_delta', delta: outputSummary });
+            sentAssistantText = true;
+          }
+        }
         send(terminal);
         close();
         return true;

--- a/packages/web/hooks/useAgentChat.ts
+++ b/packages/web/hooks/useAgentChat.ts
@@ -37,6 +37,7 @@ type AgentRequestRuntime = AgentRuntimeIdentity & {
 };
 
 const MINDOS_RUNTIME: AgentRuntimeIdentity = { ...MINDOS_AGENT, kind: 'mindos' };
+const ESTABLISHED_RUN_REATTACH_ATTEMPTS = 180;
 
 function runtimeForAgentRequest(runtime: AgentRequestRuntime | null | undefined): AgentRequestRuntime | null {
   if (!runtime) return null;
@@ -541,7 +542,9 @@ export function useAgentChat({
       });
 
       if (!res.ok) {
-        throw new Error(`Reconnect failed (${res.status})`);
+        const error = new Error(`Reconnect failed (${res.status})`);
+        (error as Error & { httpStatus?: number }).httpStatus = res.status;
+        throw error;
       }
       if (!res.body) throw new Error('No response body');
 
@@ -551,11 +554,16 @@ export function useAgentChat({
     try {
       let lastError: Error | null = null;
 
-      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      for (let attempt = 0; ; attempt++) {
         if (controller.signal.aborted) break;
 
         if (attempt > 0) {
-          updateRun(sessionId, { reconnectAttempt: attempt, phase: 'reconnecting' });
+          const displayMax = Math.max(1, maxRetries);
+          updateRun(sessionId, {
+            reconnectAttempt: Math.min(attempt, displayMax),
+            reconnectMax: displayMax,
+            phase: 'reconnecting',
+          });
           if (!getRun(sessionId)?.agentRunContext?.rootRunId) {
             replaceLastMessage(
               sessionId,
@@ -585,7 +593,12 @@ export function useAgentChat({
         } catch (err) {
           lastError = err instanceof Error ? err : new Error(String(err));
           const httpStatus = (err as Error & { httpStatus?: number }).httpStatus;
-          if (!isRetryableError(err, httpStatus) || attempt >= maxRetries) break;
+          if (httpStatus === 400 || httpStatus === 404 || !isRetryableError(err, httpStatus)) break;
+          const hasEstablishedRun = Boolean(getRun(sessionId)?.agentRunContext?.rootRunId);
+          const retryLimit = hasEstablishedRun
+            ? Math.max(maxRetries, ESTABLISHED_RUN_REATTACH_ATTEMPTS)
+            : maxRetries;
+          if (attempt >= retryLimit) break;
         }
       }
 


### PR DESCRIPTION
## Summary
- keep retrying reattach requests for established agent runs after the short initial reconnect limit is exhausted
- stop durable retries for explicit missing/invalid run responses
- replay a terminal run output summary when text events are unavailable, so completed background work is restored instead of ending with an empty `done`

## Reproduction
A long Codex run continued in the backend for about 15 minutes and completed successfully, but the browser stream disconnected. The run ledger and persisted chat contained the final answer, while the reconnect path stopped early or could return only `done`.

## Tests
- `pnpm --filter @mindos/web exec vitest run __tests__/api/agent-runs-reattach.test.ts __tests__/ask/ask-concurrent-sessions.test.tsx`
- related Web tests: 102 passed
- `pnpm --filter @mindos/web typecheck`
- targeted ESLint: no errors