### PR TITLE
feat: add MiniMax-M2.7 to regional model registries

### DIFF
--- a/packages/mindos/src/server/provider-settings.test.ts
+++ b/packages/mindos/src/server/provider-settings.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
+  MINDOS_PROVIDER_PRESETS,
   normalizeMindosProvider,
   parseMindosProviders,
 } from './provider-settings.js';
+
+describe('MindOS provider registry', () => {
+  it('lists MiniMax-M2.7 for both regional presets', () => {
+    const expectedModels = ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.5'];
+
+    expect(MINDOS_PROVIDER_PRESETS.minimax.registryModels).toEqual(expectedModels);
+    expect(MINDOS_PROVIDER_PRESETS['minimax-cn'].registryModels).toEqual(expectedModels);
+  });
+});
 
 describe('MindOS provider settings capability metadata', () => {
   it('preserves validated provider and per-model caps for new-format provider entries', () => {

--- a/packages/mindos/src/server/provider-settings.ts
+++ b/packages/mindos/src/server/provider-settings.ts
@@ -148,7 +148,7 @@ export const MINDOS_PROVIDER_PRESETS: Record<string, MindosProviderPreset> = {
     supportsListModels: false,
     apiType: 'anthropic-messages',
     envKeys: ['MINIMAX_API_KEY'],
-    registryModels: ['MiniMax-M3', 'MiniMax-M2.5'],
+    registryModels: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.5'],
   },
   'minimax-cn': {
     name: 'MiniMax (China)',
@@ -156,7 +156,7 @@ export const MINDOS_PROVIDER_PRESETS: Record<string, MindosProviderPreset> = {
     supportsListModels: false,
     apiType: 'anthropic-messages',
     envKeys: ['MINIMAX_API_KEY'],
-    registryModels: ['MiniMax-M3', 'MiniMax-M2.5'],
+    registryModels: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.5'],
   },
   huggingface: {
     name: 'Hugging Face',


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 to the static model registry for both regional configurations.
- Add regression coverage that keeps the two registries aligned.

## Compatibility
- Preserve existing defaults, existing model entries, regional endpoints, and compatible API routing.
- No configuration migration is required.

## Checks
- `corepack pnpm --filter @geminilight/mindos exec vitest run src/server/provider-settings.test.ts`
- `corepack pnpm --filter @geminilight/mindos type-check`
- `pnpm --filter @geminilight/mindos build`
- `pnpm --filter @geminilight/mindos test`
- `pnpm --dir packages/web exec vitest run __tests__/agent/provider-endpoints.test.ts`